### PR TITLE
Move missing platform specific metrics

### DIFF
--- a/report/metrics_file_descriptors.go
+++ b/report/metrics_file_descriptors.go
@@ -1,0 +1,59 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build linux || (freebsd && cgo)
+// +build linux freebsd,cgo
+
+package report
+
+import (
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+	"github.com/elastic/elastic-agent-system-metrics/metric/system/process"
+)
+
+func SetupLinuxBSDFDMetrics(logger *logp.Logger, reg *monitoring.Registry, processStats *process.Stats) {
+	monitoring.NewFunc(reg, "handles", FDUsageReporter(logger, processStats), monitoring.Report)
+}
+
+func FDUsageReporter(logger *logp.Logger, processStats *process.Stats) func(_ monitoring.Mode, V monitoring.Visitor) {
+	return func(_ monitoring.Mode, V monitoring.Visitor) {
+		V.OnRegistryStart()
+		defer V.OnRegistryFinished()
+
+		open, hardLimit, softLimit, err := getFDUsage(processStats)
+		if err != nil {
+			logger.Error("Error while retrieving FD information: %v", err)
+			return
+		}
+
+		monitoring.ReportInt(V, "open", int64(open))
+		monitoring.ReportNamespace(V, "limit", func() {
+			monitoring.ReportInt(V, "hard", int64(hardLimit))
+			monitoring.ReportInt(V, "soft", int64(softLimit))
+		})
+	}
+}
+
+func getFDUsage(processStats *process.Stats) (open, hardLimit, softLimit uint64, err error) {
+	state, err := processStats.GetSelf()
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	return state.FD.Open.ValueOr(0), state.FD.Limit.Hard.ValueOr(0), state.FD.Limit.Soft.ValueOr(0), nil
+}

--- a/report/metrics_file_descriptors_stub.go
+++ b/report/metrics_file_descriptors_stub.go
@@ -19,7 +19,7 @@
 // +build !linux
 // +build !freebsd !cgo
 
-package metrics
+package report
 
 import (
 	"github.com/elastic/elastic-agent-libs/logp"

--- a/report/metrics_file_descriptors_stub.go
+++ b/report/metrics_file_descriptors_stub.go
@@ -1,0 +1,32 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !linux && (!freebsd || !cgo)
+// +build !linux
+// +build !freebsd !cgo
+
+package metrics
+
+import (
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+	"github.com/elastic/elastic-agent-system-metrics/metric/system/process"
+)
+
+// FDUsage is only supported on Linux and FreeBSD.
+func SetupLinuxBSDFDMetrics(_ *logp.Logger, _ *monitoring.Registry, _ *process.Stats) {
+}

--- a/report/metrics_handles.go
+++ b/report/metrics_handles.go
@@ -61,7 +61,7 @@ func openHandlesReporter(logger *logp.Logger) func(_ monitoring.Mode, V monitori
 
 		n, err := handleCounter.OpenHandleCount()
 		if err != nil {
-			logger.Err("Error while retrieving the number of open file handles: %v", err)
+			logger.Error("Error while retrieving the number of open file handles: %v", err)
 			return
 		}
 		monitoring.ReportInt(V, "open", int64(n))

--- a/report/metrics_handles.go
+++ b/report/metrics_handles.go
@@ -1,0 +1,68 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build windows
+// +build windows
+
+package report
+
+import (
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+	sysinfo "github.com/elastic/go-sysinfo"
+	"github.com/elastic/go-sysinfo/types"
+)
+
+const (
+	fileHandlesNotReported = "Following metrics will not be reported: beat.handles.open"
+)
+
+var (
+	handleCounter types.OpenHandleCounter
+)
+
+func SetupWindowsHandlesMetrics(logger *logp.Logger, reg *monitoring.Registry) {
+	beatProcessSysInfo, err := sysinfo.Self()
+	if err != nil {
+		logger.Err("Error while getting own process info: %v", err)
+		logger.Err(fileHandlesNotReported)
+		return
+	}
+
+	var ok bool
+	handleCounter, ok = beatProcessSysInfo.(types.OpenHandleCounter)
+	if !ok {
+		logp.Err("Process does not implement types.OpenHandleCounter: %v", beatProcessSysInfo)
+		logp.Err(fileHandlesNotReported)
+		return
+	}
+
+	monitoring.NewFunc(reg, "handles", reportOpenHandles, monitoring.Report)
+}
+
+func reportOpenHandles(_ monitoring.Mode, V monitoring.Visitor) {
+	V.OnRegistryStart()
+	defer V.OnRegistryFinished()
+
+	n, err := handleCounter.OpenHandleCount()
+	if err != nil {
+		logp.Err("Error while retrieving the number of open file handles: %v", err)
+		return
+	}
+
+	monitoring.ReportInt(V, "open", int64(n))
+}

--- a/report/metrics_handles_stub.go
+++ b/report/metrics_handles_stub.go
@@ -1,0 +1,29 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !windows
+// +build !windows
+
+package report
+
+import (
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
+
+// Counting number of open handles is only supported on Windows.
+func SetupWindowsHandlesMetrics(_ *logp.Logger, _ *monitoring.Registry) {}


### PR DESCRIPTION
Two platform specific metric reporter were missing. These two reporters are required for Agent and Fleet server.