### PR TITLE
Move metrics setup to this repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/elastic/go-windows v1.0.1 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/gobuffalo/here v0.6.0 // indirect
+	github.com/gofrs/uuid v4.2.0+incompatible // indirect
 	github.com/google/licenseclassifier v0.0.0-20200402202327-879cb1424de0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gobuffalo/here v0.6.0 h1:hYrd0a6gDmWxBM4TnrGw8mQg24iSVoIkHEk7FodQcBI=
 github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PLa8Y5fM=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=
+github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/report/metrics_common.go
+++ b/report/metrics_common.go
@@ -1,0 +1,49 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package report
+
+import (
+	"time"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
+
+var (
+	ephemeralID    uuid.UUID
+	processMetrics *monitoring.Registry
+	startTime      time.Time
+)
+
+func init() {
+	startTime = time.Now()
+	processMetrics = monitoring.Default.NewRegistry("beat")
+
+	var err error
+	ephemeralID, err = uuid.NewV4()
+	if err != nil {
+		logp.Err("Error while generating ephemeral ID for Beat")
+	}
+}
+
+// EphemeralID returns generated EphemeralID
+func EphemeralID() uuid.UUID {
+	return ephemeralID
+}

--- a/report/setup.go
+++ b/report/setup.go
@@ -1,0 +1,125 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build (darwin && cgo) || (freebsd && cgo) || linux || windows
+// +build darwin,cgo freebsd,cgo linux windows
+
+package report
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+	"github.com/elastic/elastic-agent-system-metrics/metric/system/process"
+)
+
+var (
+	systemMetrics *monitoring.Registry
+
+	processStats *process.Stats
+)
+
+func init() {
+	systemMetrics = monitoring.Default.NewRegistry("system")
+}
+
+// monitoringCgroupsHierarchyOverride is an undocumented environment variable which
+// overrides the cgroups path under /sys/fs/cgroup, which should be set to "/" when running
+// Elastic Agent under Docker.
+const monitoringCgroupsHierarchyOverride = "LIBBEAT_MONITORING_CGROUPS_HIERARCHY_OVERRIDE"
+
+func SetupMetrics(logger *logp.Logger, name, version string) error {
+	monitoring.NewFunc(systemMetrics, "cpu", ReportSystemCPUUsage, monitoring.Report)
+
+	name = processName(name)
+	processStats = &process.Stats{
+		Procs:        []string{name},
+		EnvWhitelist: nil,
+		CPUTicks:     true,
+		CacheCmdLine: true,
+		IncludeTop:   process.IncludeTopConfig{},
+	}
+
+	err := processStats.Init()
+	if err != nil {
+		return fmt.Errorf("failed to init process stats for agent: %w", err)
+	}
+
+	monitoring.NewFunc(processMetrics, "memstats", MemStatsReporter(logger, processStats), monitoring.Report)
+	monitoring.NewFunc(processMetrics, "cpu", InstanceCPUReporter(logger, processStats), monitoring.Report)
+	monitoring.NewFunc(processMetrics, "runtime", ReportRuntime, monitoring.Report)
+	monitoring.NewFunc(processMetrics, "info", infoReporter(name, version), monitoring.Report)
+
+	setupPlatformSpecificMetrics(logger, processStats)
+
+	return nil
+}
+
+// processName truncates the name if it is longer than 15 characters, so we don't fail process checks later on
+// On *nix, the process name comes from /proc/PID/stat, which uses a comm value of 16 bytes, plus the null byte
+func processName(name string) string {
+	if (isLinux() || isDarwin()) && len(name) > 15 {
+		name = name[:15]
+	}
+	return name
+}
+
+func isDarwin() bool {
+	return runtime.GOOS == "darwin"
+}
+
+func isLinux() bool {
+	return runtime.GOOS == "linux"
+}
+
+func isWindows() bool {
+	return runtime.GOOS == "windows"
+}
+
+func infoReporter(serviceName, version string) func(_ monitoring.Mode, V monitoring.Visitor) {
+	return func(_ monitoring.Mode, V monitoring.Visitor) {
+		V.OnRegistryStart()
+		defer V.OnRegistryFinished()
+
+		delta := time.Since(startTime)
+		uptime := int64(delta / time.Millisecond)
+		monitoring.ReportNamespace(V, "uptime", func() {
+			monitoring.ReportInt(V, "ms", uptime)
+		})
+
+		monitoring.ReportString(V, "ephemeral_id", ephemeralID.String())
+		monitoring.ReportString(V, "name", serviceName)
+		monitoring.ReportString(V, "version", version)
+	}
+}
+
+func setupPlatformSpecificMetrics(logger *logp.Logger, processStats *process.Stats) {
+	if isLinux() {
+		monitoring.NewFunc(processMetrics, "cgroup", InstanceCroupsReporter(logger, monitoringCgroupsHierarchyOverride), monitoring.Report)
+	}
+
+	if isWindows() {
+		SetupWindowsHandlesMetrics(logger, systemMetrics)
+	} else {
+		monitoring.NewFunc(systemMetrics, "load", ReportSystemLoadAverage, monitoring.Report)
+	}
+
+	SetupLinuxBSDFDMetrics(logger, systemMetrics, processStats)
+}

--- a/report/setup_other.go
+++ b/report/setup_other.go
@@ -1,0 +1,31 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build (!darwin || !cgo) && (!freebsd || !cgo) && !linux && !windows
+// +build !darwin !cgo
+// +build !freebsd !cgo
+// +build !linux
+// +build !windows
+
+package metrics
+
+import "github.com/elastic/elastic-agent-libs/logp"
+
+func SetupMetrics(logger *logp.Logger, name, version string) error {
+	logp.Warn("Metrics not implemented for this OS.")
+	return nil
+}


### PR DESCRIPTION
This PR moves the metrics setup from Beats to a common place. Previously the reporter functions were used in Agent to provide some flexibility. But it turns out that flexibility is not needed, and avoiding CGO is more important.

This PR is also required by fleet-server: https://github.com/elastic/fleet-server/pull/1351