### PR TITLE
Fix package name for `setup` for other platforms

### DIFF
--- a/report/setup_other.go
+++ b/report/setup_other.go
@@ -21,7 +21,7 @@
 // +build !linux
 // +build !windows
 
-package metrics
+package report
 
 import "github.com/elastic/elastic-agent-libs/logp"
 


### PR DESCRIPTION
Fix the incorrect package name so the module can be used on multiple flatforms:
```
found packages report (metrics_common.go) and metrics (setup_other.go) in /go/pkg/mod/github.com/elastic/elastic-agent-system-metrics@v0.2.0/report
```