### PR TITLE
Revert changes that removed filesystem code

### DIFF
--- a/metric/system/filesystem/filesystem.go
+++ b/metric/system/filesystem/filesystem.go
@@ -1,0 +1,201 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build darwin || freebsd || linux || openbsd || windows
+// +build darwin freebsd linux openbsd windows
+
+package filesystem
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/opt"
+	"github.com/elastic/elastic-agent-system-metrics/metric"
+	"github.com/elastic/elastic-agent-system-metrics/metric/system/resolve"
+)
+
+//FSStat carries the metadata for a given filesystem
+type FSStat struct {
+	Directory string   `struct:"mount_point,omitempty"`
+	Device    string   `struct:"device_name,omitempty"`
+	Type      string   `struct:"type,omitempty"`
+	Options   string   `struct:"options,omitempty"`
+	Flags     opt.Uint `struct:"flags,omitempty"`
+	// metrics
+	Total     opt.Uint `struct:"total,omitempty"`
+	Free      opt.Uint `struct:"free,omitempty"`
+	Avail     opt.Uint `struct:"available,omitempty"`
+	Used      UsedVals `struct:"used,omitempty"`
+	Files     opt.Uint `struct:"files,omitempty"`
+	FreeFiles opt.Uint `struct:"free_files,omitempty"`
+}
+
+// UsedVals wraps the `used` disk metrics
+type UsedVals struct {
+	Pct   opt.Float `struct:"pct,omitempty"`
+	Bytes opt.Uint  `struct:"bytes,omitempty"`
+}
+
+// IsZero implements the IsZero interface for go-structform
+func (u UsedVals) IsZero() bool {
+	return u.Pct.IsZero() && u.Bytes.IsZero()
+}
+
+var debugf = logp.MakeDebug("libbeat.filesystem")
+
+func getFSPath(hostfs resolve.Resolver) string {
+	// Do a little work to make sure we don't break anything.
+	// This code would previously just blindly just search for /etc/mtab
+	// This wasn't available on certain containerized workflows,
+	// So default to mtab's symlink of /proc/self/mounts
+	// However, I'm a little skeptical of `self` inside containers,
+	// so if hostfs is set, use /hostfs/proc/mounts
+	if hostfs.IsSet() {
+		return hostfs.ResolveHostFS("/proc/mounts")
+	}
+	return hostfs.ResolveHostFS("/proc/self/mounts")
+
+}
+
+// GetFilesystems returns a filesystem list filtered by the callback function
+func GetFilesystems(hostfs resolve.Resolver, filter func(FSStat) bool) ([]FSStat, error) {
+	fs := getFSPath(hostfs)
+
+	if filter == nil {
+		filter = buildDefaultFilters(hostfs)
+	}
+
+	//combine user-supplied and built-in filters
+	filterFunc := func(fs FSStat) bool {
+		return avoidFileSystem(fs) && filter(fs)
+	}
+
+	mounts, err := parseMounts(fs, filterFunc)
+	if err != nil {
+		return nil, fmt.Errorf("error reading mounts: %w", err)
+	}
+
+	return filterDuplicates(mounts), nil
+
+}
+
+// Fill out computed stats after the platform-specific code fetches metrics from the OS
+func (fs *FSStat) fillMetrics() {
+	fs.Used.Bytes = fs.Total.SubtractOrNone(fs.Free)
+
+	// I'm not sure why this does Used + avail instead of total, but I'm too afraid to change it
+	percTotal := fs.Used.Bytes.ValueOr(0) + fs.Avail.ValueOr(0)
+	if percTotal == 0 {
+		return
+	}
+
+	perc := float64(fs.Used.Bytes.ValueOr(0)) / float64(percTotal)
+	fs.Used.Pct = opt.FloatWith(metric.Round(perc))
+}
+
+// DefaultIgnoredTypes tries to guess a sane list of filesystem types that
+// could be ignored in the running system
+func DefaultIgnoredTypes(sys resolve.Resolver) []string {
+	// If /proc/filesystems exist, default ignored types are all marked
+	// as nodev
+	types := []string{}
+	fsListFile := sys.ResolveHostFS("/proc/filesystems")
+	if f, err := os.Open(fsListFile); err == nil {
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			line := strings.Fields(scanner.Text())
+			if len(line) == 2 && line[0] == "nodev" {
+				types = append(types, line[1])
+			}
+		}
+	}
+	return types
+}
+
+// BuildFilterWithList returns a filesystem filter with the given list of FS types
+func BuildFilterWithList(ignored []string) func(FSStat) bool {
+	return func(fs FSStat) bool {
+		for _, fsType := range ignored {
+			// XXX (andrewkroh): SystemType appears to be used for non-Windows
+			// and Type is used exclusively for Windows.
+			if fs.Type == fsType {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+func buildDefaultFilters(hostfs resolve.Resolver) func(FSStat) bool {
+	ignoreType := DefaultIgnoredTypes(hostfs)
+	return BuildFilterWithList(ignoreType)
+}
+
+// If a block device is mounted multiple times (e.g. with some bind mounts),
+// store it only once, and use the shorter mount point path.
+func filterDuplicates(fsList []FSStat) []FSStat {
+	devices := make(map[string]FSStat)
+	filtered := []FSStat{}
+
+	for _, fs := range fsList {
+		// Don't do any further checks on block devices
+		if !filepath.IsAbs(fs.Device) {
+			filtered = append(filtered, fs)
+			continue
+		}
+		if seen, found := devices[fs.Device]; found {
+			if len(fs.Directory) < len(seen.Directory) {
+				devices[fs.Device] = fs
+			}
+			continue
+		}
+		devices[fs.Device] = fs
+	}
+
+	for _, fs := range devices {
+		filtered = append(filtered, fs)
+	}
+
+	return filtered
+}
+
+func avoidFileSystem(fs FSStat) bool {
+	// Ignore relative mount points, which are present for example
+	// in /proc/mounts on Linux with network namespaces.
+	if !filepath.IsAbs(fs.Directory) {
+		debugf("Filtering filesystem with relative mountpoint %+v", fs)
+		return false
+	}
+
+	// Don't do further checks in special devices
+	if !filepath.IsAbs(fs.Device) {
+		return true
+	}
+
+	// If the device name is a directory, this is a bind mount or nullfs,
+	// don't count it as it'd be counting again its parent filesystem.
+	devFileInfo, _ := os.Stat(fs.Device)
+	if devFileInfo != nil && devFileInfo.IsDir() {
+		return false
+	}
+	return true
+}

--- a/metric/system/filesystem/filesystem.go
+++ b/metric/system/filesystem/filesystem.go
@@ -135,8 +135,6 @@ func DefaultIgnoredTypes(sys resolve.Resolver) []string {
 func BuildFilterWithList(ignored []string) func(FSStat) bool {
 	return func(fs FSStat) bool {
 		for _, fsType := range ignored {
-			// XXX (andrewkroh): SystemType appears to be used for non-Windows
-			// and Type is used exclusively for Windows.
 			if fs.Type == fsType {
 				return false
 			}
@@ -181,6 +179,7 @@ func filterDuplicates(fsList []FSStat) []FSStat {
 func avoidFileSystem(fs FSStat) bool {
 	// Ignore relative mount points, which are present for example
 	// in /proc/mounts on Linux with network namespaces.
+	debugf("filtering: %#v", fs)
 	if !filepath.IsAbs(fs.Directory) {
 		debugf("Filtering filesystem with relative mountpoint %+v", fs)
 		return false

--- a/metric/system/filesystem/filesystem.go
+++ b/metric/system/filesystem/filesystem.go
@@ -192,8 +192,10 @@ func avoidFileSystem(fs FSStat) bool {
 
 	// If the device name is a directory, this is a bind mount or nullfs,
 	// don't count it as it'd be counting again its parent filesystem.
-	devFileInfo, _ := os.Stat(fs.Device)
+	devFileInfo, err := os.Stat(fs.Device)
+	debugf("error stating filesystem: %s", err)
 	if devFileInfo != nil && devFileInfo.IsDir() {
+		debugf("device %s is dir", fs.Device)
 		return false
 	}
 	return true

--- a/metric/system/filesystem/filesystem_darwin.go
+++ b/metric/system/filesystem/filesystem_darwin.go
@@ -1,0 +1,75 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filesystem
+
+/*
+#include <stdlib.h>
+#include <sys/sysctl.h>
+#include <sys/mount.h>
+#include <mach/mach_init.h>
+#include <mach/mach_host.h>
+#include <mach/host_info.h>
+#include <libproc.h>
+#include <mach/processor_info.h>
+#include <mach/vm_map.h>
+*/
+import "C"
+
+import (
+	"bytes"
+	"syscall"
+)
+
+func parseMounts(path string, filter func(FSStat) bool) ([]FSStat, error) {
+	num, err := syscall.Getfsstat(nil, C.MNT_NOWAIT)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := make([]syscall.Statfs_t, num)
+
+	_, err = syscall.Getfsstat(buf, C.MNT_NOWAIT)
+	if err != nil {
+		return nil, err
+	}
+
+	fslist := make([]FSStat, 0, num)
+
+	for i := 0; i < num; i++ {
+		fs := FSStat{}
+		fs.Directory = byteListToString(buf[i].Mntonname[:])
+		fs.Device = byteListToString(buf[i].Mntfromname[:])
+		fs.Type = byteListToString(buf[i].Fstypename[:])
+
+		fslist = append(fslist, fs)
+	}
+	return fslist, nil
+}
+
+func byteListToString(raw []int8) string {
+	byteList := make([]byte, len(raw))
+
+	for pos, singleByte := range raw {
+		byteList[pos] = byte(singleByte)
+		if singleByte == 0 {
+			break
+		}
+	}
+
+	return string(bytes.Trim(byteList, "\x00"))
+}

--- a/metric/system/filesystem/filesystem_darwin.go
+++ b/metric/system/filesystem/filesystem_darwin.go
@@ -56,7 +56,10 @@ func parseMounts(path string, filter func(FSStat) bool) ([]FSStat, error) {
 		fs.Device = byteListToString(buf[i].Mntfromname[:])
 		fs.Type = byteListToString(buf[i].Fstypename[:])
 
-		fslist = append(fslist, fs)
+		if filter(fs) {
+			fslist = append(fslist, fs)
+		}
+
 	}
 	return fslist, nil
 }

--- a/metric/system/filesystem/filesystem_test.go
+++ b/metric/system/filesystem/filesystem_test.go
@@ -54,7 +54,7 @@ func TestFileSystemList(t *testing.T) {
 	}
 	hostfs := resolve.NewTestResolver("/")
 	//Exclude FS types that will give us a permission error
-	fss, err := GetFilesystems(hostfs, BuildFilterWithList([]string{"cdrom", "tracefs", "overlay", "fuse.lxcfs", "fuse.gvfsd-fuse", "nsfs", "squashfs"}))
+	fss, err := GetFilesystems(hostfs, BuildFilterWithList([]string{"cdrom", "tracefs", "overlay", "fuse.lxcfs", "fuse.gvfsd-fuse", "nsfs", "squashfs", "vmhgfs"}))
 	if err != nil {
 		t.Fatal("GetFileSystemList", err)
 	}

--- a/metric/system/filesystem/filesystem_test.go
+++ b/metric/system/filesystem/filesystem_test.go
@@ -62,7 +62,7 @@ func TestFileSystemList(t *testing.T) {
 
 	for _, fs := range fss {
 		err := fs.GetUsage()
-		assert.NoError(t, err, "filesystem=%v: %v", fs, err)
+		assert.NoError(t, err, "filesystem=%#v: %v", fs, err)
 
 	}
 }

--- a/metric/system/filesystem/filesystem_test.go
+++ b/metric/system/filesystem/filesystem_test.go
@@ -32,9 +32,13 @@ func TestFileSystemList(t *testing.T) {
 	if runtime.GOOS == "darwin" && os.Getenv("TRAVIS") == "true" {
 		t.Skip("FileSystem test fails on Travis/OSX with i/o error")
 	}
+	skipTypes := []string{"cdrom", "tracefs", "overlay", "fuse.lxcfs", "fuse.gvfsd-fuse", "nsfs", "squashfs", "vmhgfs"}
+	if runtime.GOOS == "windows" {
+		skipTypes = []string{"cdrom"}
+	}
 	hostfs := resolve.NewTestResolver("/")
 	//Exclude FS types that will give us a permission error
-	fss, err := GetFilesystems(hostfs, BuildFilterWithList([]string{"cdrom", "tracefs", "overlay", "fuse.lxcfs", "fuse.gvfsd-fuse", "nsfs", "squashfs", "vmhgfs"}))
+	fss, err := GetFilesystems(hostfs, BuildFilterWithList(skipTypes))
 	if err != nil {
 		t.Fatal("GetFileSystemList", err)
 	}
@@ -48,9 +52,9 @@ func TestFileSystemList(t *testing.T) {
 }
 
 func TestFileSystemListFiltering(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("These cases don't need to work on Windows")
-	}
+	// if runtime.GOOS == "windows" {
+	// 	t.Skip("These cases don't need to work on Windows")
+	// }
 
 	fakeDevDir, err := ioutil.TempDir(os.TempDir(), "dir")
 	assert.Empty(t, err)

--- a/metric/system/filesystem/filesystem_test.go
+++ b/metric/system/filesystem/filesystem_test.go
@@ -25,28 +25,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/elastic/elastic-agent-libs/mapstr"
-	"github.com/elastic/elastic-agent-libs/transform/typeconv"
 	"github.com/elastic/elastic-agent-system-metrics/metric/system/resolve"
 )
-
-func TestMountList(t *testing.T) {
-	hostfs := resolve.NewTestResolver("/")
-
-	result, err := GetFilesystems(hostfs, nil)
-	assert.NoError(t, err, "GetFilesystems")
-
-	t.Logf("Usage:")
-
-	for _, res := range result {
-		err := res.GetUsage()
-		assert.NoError(t, err, "getUsage")
-		out := mapstr.M{}
-		err = typeconv.Convert(&out, res)
-		assert.NoError(t, err, "typeconv")
-		t.Logf("Usage: %s", out.StringToPrint())
-	}
-}
 
 func TestFileSystemList(t *testing.T) {
 	if runtime.GOOS == "darwin" && os.Getenv("TRAVIS") == "true" {

--- a/metric/system/filesystem/filesystem_test.go
+++ b/metric/system/filesystem/filesystem_test.go
@@ -1,0 +1,198 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filesystem
+
+import (
+	"io/ioutil"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/elastic-agent-libs/mapstr"
+	"github.com/elastic/elastic-agent-libs/transform/typeconv"
+	"github.com/elastic/elastic-agent-system-metrics/metric/system/resolve"
+)
+
+func TestMountList(t *testing.T) {
+	hostfs := resolve.NewTestResolver("/")
+
+	result, err := GetFilesystems(hostfs, nil)
+	assert.NoError(t, err, "GetFilesystems")
+
+	t.Logf("Usage:")
+
+	for _, res := range result {
+		err := res.GetUsage()
+		assert.NoError(t, err, "getUsage")
+		out := mapstr.M{}
+		err = typeconv.Convert(&out, res)
+		assert.NoError(t, err, "typeconv")
+		t.Logf("Usage: %s", out.StringToPrint())
+	}
+}
+
+func TestFileSystemList(t *testing.T) {
+	if runtime.GOOS == "darwin" && os.Getenv("TRAVIS") == "true" {
+		t.Skip("FileSystem test fails on Travis/OSX with i/o error")
+	}
+	hostfs := resolve.NewTestResolver("/")
+	//Exclude FS types that will give us a permission error
+	fss, err := GetFilesystems(hostfs, BuildFilterWithList([]string{"cdrom", "tracefs", "overlay", "fuse.lxcfs", "fuse.gvfsd-fuse", "nsfs", "squashfs"}))
+	if err != nil {
+		t.Fatal("GetFileSystemList", err)
+	}
+	assert.True(t, (len(fss) > 0))
+
+	for _, fs := range fss {
+		err := fs.GetUsage()
+		assert.NoError(t, err, "filesystem=%v: %v", fs, err)
+
+	}
+}
+
+func TestFileSystemListFiltering(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("These cases don't need to work on Windows")
+	}
+
+	fakeDevDir, err := ioutil.TempDir(os.TempDir(), "dir")
+	assert.Empty(t, err)
+	defer os.RemoveAll(fakeDevDir)
+
+	cases := []struct {
+		description   string
+		fss, expected []FSStat
+	}{
+		{
+			fss: []FSStat{
+				{Directory: "/", Device: "/dev/sda1"},
+				{Directory: "/", Device: "/dev/sda1"},
+			},
+			expected: []FSStat{
+				{Directory: "/", Device: "/dev/sda1"},
+			},
+		},
+		{
+			description: "Don't repeat devices, shortest of dir names should be used",
+			fss: []FSStat{
+				{Directory: "/", Device: "/dev/sda1"},
+				{Directory: "/bind", Device: "/dev/sda1"},
+			},
+			expected: []FSStat{
+				{Directory: "/", Device: "/dev/sda1"},
+			},
+		},
+		{
+			description: "Don't repeat devices, shortest of dir names should be used",
+			fss: []FSStat{
+				{Directory: "/bind", Device: "/dev/sda1"},
+				{Directory: "/", Device: "/dev/sda1"},
+			},
+			expected: []FSStat{
+				{Directory: "/", Device: "/dev/sda1"},
+			},
+		},
+		{
+			description: "Keep tmpfs",
+			fss: []FSStat{
+				{Directory: "/run", Device: "tmpfs"},
+				{Directory: "/tmp", Device: "tmpfs"},
+			},
+			expected: []FSStat{
+				{Directory: "/run", Device: "tmpfs"},
+				{Directory: "/tmp", Device: "tmpfs"},
+			},
+		},
+		{
+			description: "Don't repeat devices, shortest of dir names should be used, keep tmpfs",
+			fss: []FSStat{
+				{Directory: "/", Device: "/dev/sda1"},
+				{Directory: "/bind", Device: "/dev/sda1"},
+				{Directory: "/run", Device: "tmpfs"},
+			},
+			expected: []FSStat{
+				{Directory: "/", Device: "/dev/sda1"},
+				{Directory: "/run", Device: "tmpfs"},
+			},
+		},
+		{
+			description: "Don't keep the fs if the device is a directory (it'd be a bind mount)",
+			fss: []FSStat{
+				{Directory: "/", Device: "/dev/sda1"},
+				{Directory: "/bind", Device: fakeDevDir},
+			},
+			expected: []FSStat{
+				{Directory: "/", Device: "/dev/sda1"},
+			},
+		},
+		{
+			description: "Don't filter out NFS",
+			fss: []FSStat{
+				{Directory: "/srv/data", Device: "192.168.42.42:/exports/nfs1"},
+			},
+			expected: []FSStat{
+				{Directory: "/srv/data", Device: "192.168.42.42:/exports/nfs1"},
+			},
+		},
+	}
+
+	for _, c := range cases {
+
+		filtered := filterFileSystemList(c.fss)
+		ok := assert.ElementsMatch(t, c.expected, filtered, c.description)
+		if !ok {
+			t.FailNow()
+		}
+	}
+}
+
+// Emulate the filtering process that would normally happen inside the callbacks from platform-specific code
+func filterFileSystemList(stats []FSStat) []FSStat {
+	hostfs := resolve.NewTestResolver("/")
+	filtered := []FSStat{}
+	for _, stat := range stats {
+		if avoidFileSystem(stat) && buildDefaultFilters(hostfs)(stat) {
+			filtered = append(filtered, stat)
+		}
+
+	}
+
+	return filterDuplicates(filtered)
+}
+
+func TestFilter(t *testing.T) {
+	in := []FSStat{
+		{Type: "nfs"},
+		{Type: "ext4"},
+		{Type: "proc"},
+		{Type: "smb"},
+	}
+	filter := BuildFilterWithList([]string{"nfs", "smb", "proc"})
+	out := []FSStat{}
+	for _, fs := range in {
+		if filter(fs) {
+			out = append(out, fs)
+		}
+	}
+
+	if assert.Len(t, out, 1) {
+		assert.Equal(t, "ext4", out[0].Type)
+	}
+}

--- a/metric/system/filesystem/filesystem_test.go
+++ b/metric/system/filesystem/filesystem_test.go
@@ -35,9 +35,6 @@ func TestFileSystemList(t *testing.T) {
 		t.Skip("FileSystem test fails on Travis/OSX with i/o error")
 	}
 	skipTypes := []string{"cdrom", "tracefs", "overlay", "fuse.lxcfs", "fuse.gvfsd-fuse", "nsfs", "squashfs", "vmhgfs"}
-	if runtime.GOOS == "windows" {
-		skipTypes = []string{"cdrom"}
-	}
 	hostfs := resolve.NewTestResolver("/")
 	//Exclude FS types that will give us a permission error
 	fss, err := GetFilesystems(hostfs, BuildFilterWithList(skipTypes))
@@ -54,9 +51,10 @@ func TestFileSystemList(t *testing.T) {
 }
 
 func TestFileSystemListFiltering(t *testing.T) {
-	// if runtime.GOOS == "windows" {
-	// 	t.Skip("These cases don't need to work on Windows")
-	// }
+	if runtime.GOOS == "windows" {
+		// Windows doesn't like these unix paths, the OS-specific code in stdlib will return different results.
+		t.Skip("These cases don't need to work on Windows")
+	}
 	_ = logp.DevelopmentSetup()
 	fakeDevDir, err := ioutil.TempDir(os.TempDir(), "dir")
 	assert.Empty(t, err)

--- a/metric/system/filesystem/filesystem_test.go
+++ b/metric/system/filesystem/filesystem_test.go
@@ -25,10 +25,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-system-metrics/metric/system/resolve"
 )
 
 func TestFileSystemList(t *testing.T) {
+	_ = logp.DevelopmentSetup()
 	if runtime.GOOS == "darwin" && os.Getenv("TRAVIS") == "true" {
 		t.Skip("FileSystem test fails on Travis/OSX with i/o error")
 	}
@@ -55,7 +57,7 @@ func TestFileSystemListFiltering(t *testing.T) {
 	// if runtime.GOOS == "windows" {
 	// 	t.Skip("These cases don't need to work on Windows")
 	// }
-
+	_ = logp.DevelopmentSetup()
 	fakeDevDir, err := ioutil.TempDir(os.TempDir(), "dir")
 	assert.Empty(t, err)
 	defer os.RemoveAll(fakeDevDir)
@@ -65,6 +67,7 @@ func TestFileSystemListFiltering(t *testing.T) {
 		fss, expected []FSStat
 	}{
 		{
+			description: "basic filter test to remove duplicates",
 			fss: []FSStat{
 				{Directory: "/", Device: "/dev/sda1"},
 				{Directory: "/", Device: "/dev/sda1"},

--- a/metric/system/filesystem/filesystem_unix.go
+++ b/metric/system/filesystem/filesystem_unix.go
@@ -1,0 +1,47 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build aix || darwin || freebsd || linux
+// +build aix darwin freebsd linux
+
+package filesystem
+
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/elastic/elastic-agent-libs/opt"
+)
+
+// GetUsage returns the filesystem usage
+func (fs *FSStat) GetUsage() error {
+	stat := syscall.Statfs_t{}
+	err := syscall.Statfs(fs.Directory, &stat)
+	if err != nil {
+		return fmt.Errorf("error in Statfs syscall: %w", err)
+	}
+
+	fs.Total = opt.UintWith(stat.Blocks).MultUint64OrNone(uint64(stat.Bsize))
+	fs.Free = opt.UintWith(stat.Bfree).MultUint64OrNone(uint64(stat.Bsize))
+	fs.Avail = opt.UintWith(stat.Bavail).MultUint64OrNone(uint64(stat.Bsize))
+	fs.Files = opt.UintWith(stat.Files)
+	fs.FreeFiles = opt.UintWith(stat.Ffree)
+
+	fs.fillMetrics()
+
+	return nil
+}

--- a/metric/system/filesystem/filesystem_unix_common.go
+++ b/metric/system/filesystem/filesystem_unix_common.go
@@ -1,0 +1,53 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build freebsd || linux
+// +build freebsd linux
+
+package filesystem
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// actually get the list of mounts on linux
+func parseMounts(path string, filter func(FSStat) bool) ([]FSStat, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading mount file %s: %w", path, err)
+	}
+	fsList := []FSStat{}
+	for _, line := range strings.Split(string(raw), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		fs := FSStat{
+			Device:    fields[0],
+			Directory: fields[1],
+			Type:      fields[2],
+			Options:   fields[3],
+		}
+		if filter(fs) {
+			fsList = append(fsList, fs)
+		}
+	}
+
+	return fsList, nil
+}

--- a/metric/system/filesystem/filesystem_windows.go
+++ b/metric/system/filesystem/filesystem_windows.go
@@ -1,0 +1,64 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filesystem
+
+import (
+	"fmt"
+
+	"github.com/elastic/elastic-agent-libs/opt"
+	"github.com/elastic/gosigar/sys/windows"
+)
+
+func parseMounts(_ string, filter func(FSStat) bool) ([]FSStat, error) {
+	drives, err := windows.GetAccessPaths()
+	if err != nil {
+		return nil, fmt.Errorf("GetAccessPaths failed: %w", err)
+	}
+
+	driveList := []FSStat{}
+	for _, drive := range drives {
+		fsType, err := windows.GetFilesystemType(drive)
+		if err != nil {
+			return nil, fmt.Errorf("GetFilesystemType failed: %w", err)
+		}
+		if fsType != "" {
+			driveList = append(driveList, FSStat{
+				Directory: drive,
+				Device:    drive,
+				Type:      fsType,
+			})
+		}
+	}
+
+	return driveList, nil
+}
+
+func (fs *FSStat) GetUsage() error {
+	freeBytesAvailable, totalNumberOfBytes, totalNumberOfFreeBytes, err := windows.GetDiskFreeSpaceEx(fs.Directory)
+	if err != nil {
+		return fmt.Errorf("GetDiskFreeSpaceEx failed: %w", err)
+	}
+
+	fs.Total = opt.UintWith(totalNumberOfBytes)
+	fs.Free = opt.UintWith(totalNumberOfFreeBytes)
+	fs.Avail = opt.UintWith(freeBytesAvailable)
+
+	fs.fillMetrics()
+
+	return nil
+}

--- a/metric/system/filesystem/filesystem_windows.go
+++ b/metric/system/filesystem/filesystem_windows.go
@@ -36,7 +36,7 @@ func parseMounts(_ string, filter func(FSStat) bool) ([]FSStat, error) {
 		if err != nil {
 			return nil, fmt.Errorf("GetFilesystemType failed: %w", err)
 		}
-		if fsType != "" {
+		if fsType != "" && filter(fs) {
 			driveList = append(driveList, FSStat{
 				Directory: drive,
 				Device:    drive,

--- a/metric/system/filesystem/filesystem_windows.go
+++ b/metric/system/filesystem/filesystem_windows.go
@@ -36,12 +36,13 @@ func parseMounts(_ string, filter func(FSStat) bool) ([]FSStat, error) {
 		if err != nil {
 			return nil, fmt.Errorf("GetFilesystemType failed: %w", err)
 		}
+		fs := FSStat{
+			Directory: drive,
+			Device:    drive,
+			Type:      fsType,
+		}
 		if fsType != "" && filter(fs) {
-			driveList = append(driveList, FSStat{
-				Directory: drive,
-				Device:    drive,
-				Type:      fsType,
-			})
+			driveList = append(driveList)
 		}
 	}
 

--- a/metric/system/filesystem/filesystem_windows.go
+++ b/metric/system/filesystem/filesystem_windows.go
@@ -42,7 +42,7 @@ func parseMounts(_ string, filter func(FSStat) bool) ([]FSStat, error) {
 			Type:      fsType,
 		}
 		if fsType != "" && filter(fs) {
-			driveList = append(driveList)
+			driveList = append(driveList, fs)
 		}
 	}
 


### PR DESCRIPTION
Due to some miscommunication over what was going where, #7 removed the PR that added the new refactored filesystem code, so this adds it back in.