### PR TITLE
Pick process list filtering fix from elastic/beats#31595

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -90,7 +90,7 @@ linters-settings:
     # minimal length of string constant, 3 by default
     min-len: 3
     # minimal occurrences count to trigger, 3 by default
-    min-occurrences: 2
+    min-occurrences: 5
 
   dupl:
     # tokens count to trigger issue, 150 by default

--- a/metric/system/cgroup/cgv2/memory.go
+++ b/metric/system/cgroup/cgv2/memory.go
@@ -232,7 +232,7 @@ func fetchEventsFile(path, file string) (Events, error) {
 			evt.Low = opt.UintWith(val)
 		case "high":
 			evt.High = val
-		case "max": //nolint: goconst // we are not winning anything
+		case "max":
 			evt.Max = val
 		case "oom":
 			evt.OOM = opt.UintWith(val)

--- a/metric/system/filesystem/filesystem.go
+++ b/metric/system/filesystem/filesystem.go
@@ -191,7 +191,7 @@ func avoidFileSystem(fs FSStat) bool {
 	}
 
 	// This logic only applies on non-windows machines, the device path logic seems to be different on windows.
-	if runtime.GOOS != "windows" { //nolint:goconst // Not needed here
+	if runtime.GOOS != "windows" {
 		// If the device name is a directory, this is a bind mount or nullfs,
 		// don't count it as it'd be counting again its parent filesystem.
 		devFileInfo, err := os.Stat(fs.Device)

--- a/metric/system/process/helpers.go
+++ b/metric/system/process/helpers.go
@@ -18,6 +18,7 @@
 package process
 
 import (
+	"math"
 	"time"
 
 	"github.com/elastic/elastic-agent-libs/opt"
@@ -84,6 +85,11 @@ func GetProcCPUPercentage(s0, s1 ProcState) ProcState {
 	totalCPUDeltaMillis := int64(s1.CPU.Total.Ticks.ValueOr(0) - s0.CPU.Total.Ticks.ValueOr(0))
 
 	pct := float64(totalCPUDeltaMillis) / float64(timeDeltaDur)
+	// In theory this can only happen if the time delta is 0, which is unlikely but possible.
+	// With all the type conversion and non-integer math, this is probably the safest way to check.
+	if math.IsNaN(pct) {
+		return s1
+	}
 	normalizedPct := pct / float64(numcpu.NumCPU())
 
 	s1.CPU.Total.Norm.Pct = opt.FloatWith(metric.Round(normalizedPct))

--- a/metric/system/process/helpers.go
+++ b/metric/system/process/helpers.go
@@ -33,11 +33,11 @@ func unixTimeMsToTime(unixTimeMs uint64) string {
 	return typeconv.Time(time.Unix(0, int64(unixTimeMs*1000000))).String()
 }
 
-func stripNullByte(buf []byte) string { //nolint: deadcode,unused // it is used in platform specific code
+func stripNullByte(buf []byte) string { //nolint: deadcode,unused,nolintlint // it is used in platform specific code
 	return string(buf[0 : len(buf)-1])
 }
 
-func stripNullByteRaw(buf []byte) []byte { //nolint: deadcode,unused // it is used in platform specific code
+func stripNullByteRaw(buf []byte) []byte { //nolint: deadcode,unused,nolintlint // it is used in platform specific code
 	return buf[0 : len(buf)-1]
 }
 

--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -72,7 +72,7 @@ func (procStats *Stats) Get() ([]mapstr.M, []mapstr.M, error) {
 	procStats.ProcsMap = pidMap
 
 	// filter the process list that will be passed down to users
-	procStats.includeTopProcesses(plist)
+	plist = procStats.includeTopProcesses(plist)
 
 	// This is a holdover until we migrate this library to metricbeat/internal
 	// At which point we'll use the memory code there.

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -134,7 +134,9 @@ func TestGetProcess(t *testing.T) {
 	// Memory Checks
 	assert.True(t, process.Memory.Size.Exists())
 	assert.True(t, (process.Memory.Rss.Bytes.ValueOr(0) > 0))
-	assert.True(t, process.Memory.Share.Exists())
+	if runtime.GOOS != "windows" {
+		assert.True(t, process.Memory.Share.Exists())
+	}
 
 	// CPU Checks
 	assert.True(t, (process.CPU.Total.Value.ValueOr(0) >= 0))

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -134,7 +134,7 @@ func TestGetProcess(t *testing.T) {
 	// Memory Checks
 	assert.True(t, process.Memory.Size.Exists())
 	assert.True(t, (process.Memory.Rss.Bytes.ValueOr(0) > 0))
-	if runtime.GOOS != "windows" {
+	if runtime.GOOS == "linux" {
 		assert.True(t, process.Memory.Share.Exists())
 	}
 

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -41,13 +41,13 @@ func TestGetOne(t *testing.T) {
 	testConfig := Stats{
 		Procs:        []string{".*"},
 		Hostfs:       resolve.NewTestResolver("/"),
-		CPUTicks:     true,
+		CPUTicks:     false,
 		CacheCmdLine: true,
 		EnvWhitelist: []string{".*"},
 		IncludeTop: IncludeTopConfig{
 			Enabled:  true,
 			ByCPU:    4,
-			ByMemory: 4,
+			ByMemory: 0,
 		},
 		EnableCgroups: false,
 		CgroupOpts: cgroup.ReaderOptions{
@@ -58,9 +58,54 @@ func TestGetOne(t *testing.T) {
 	err := testConfig.Init()
 	assert.NoError(t, err, "Init")
 
+	_, _, err = testConfig.Get()
+	assert.NoError(t, err, "GetOne")
+
+	time.Sleep(time.Second * 2)
+
+	procData, _, err := testConfig.Get()
+	assert.NoError(t, err, "GetOne")
+
+	t.Logf("Proc: %s", procData[0].StringToPrint())
+}
+
+func TestFilter(t *testing.T) {
+	//The logic itself is os-independent, so we'll only test this on the platform least likly to have CI issues
+	if runtime.GOOS != "linux" {
+		t.Skip("Run on Linux only")
+	}
+	testConfig := Stats{
+		Procs:  []string{".*"},
+		Hostfs: resolve.NewTestResolver("/"),
+		IncludeTop: IncludeTopConfig{
+			Enabled:  true,
+			ByCPU:    1,
+			ByMemory: 1,
+		},
+	}
+	err := testConfig.Init()
+	assert.NoError(t, err, "Init")
+
 	procData, err := testConfig.GetOne(os.Getpid())
 	assert.NoError(t, err, "GetOne")
-	t.Logf("Proc: %s", procData.StringToPrint())
+	assert.Equal(t, 2, len(procData))
+
+	testZero := Stats{
+		Procs:  []string{".*"},
+		Hostfs: resolve.NewTestResolver("/"),
+		IncludeTop: IncludeTopConfig{
+			Enabled:  true,
+			ByCPU:    0,
+			ByMemory: 1,
+		},
+	}
+
+	err = testZero.Init()
+	assert.NoError(t, err, "Init")
+
+	oneData, _, err := testZero.Get()
+	assert.NoError(t, err, "GetOne with one event")
+	assert.Equal(t, 1, len(oneData))
 }
 
 func TestProcessList(t *testing.T) {
@@ -99,7 +144,7 @@ func TestGetProcess(t *testing.T) {
 	assert.True(t, (process.SampleTime.Unix() <= time.Now().Unix()))
 
 	switch runtime.GOOS {
-	case "darwin", "linux", "freebsd": //nolint: goconst // it is just a test file
+	case "darwin", "linux", "freebsd":
 		assert.True(t, len(process.Env) > 0, "empty environment")
 	}
 

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -86,7 +86,7 @@ func TestFilter(t *testing.T) {
 	err := testConfig.Init()
 	assert.NoError(t, err, "Init")
 
-	procData, err := testConfig.GetOne(os.Getpid())
+	procData, _, err := testConfig.Get()
 	assert.NoError(t, err, "GetOne")
 	assert.Equal(t, 2, len(procData))
 
@@ -132,14 +132,14 @@ func TestGetProcess(t *testing.T) {
 	assert.NotEqual(t, "unknown", process.State)
 
 	// Memory Checks
-	assert.True(t, (process.Memory.Size.ValueOr(0) >= 0))      //nolint: staticcheck // it's not pointless in this case?
-	assert.True(t, (process.Memory.Rss.Bytes.ValueOr(0) >= 0)) //nolint: staticcheck // it's not pointless in this case?
-	assert.True(t, (process.Memory.Share.ValueOr(0) >= 0))     //nolint: staticcheck // it's not pointless in this case?
+	assert.True(t, process.Memory.Size.Exists())
+	assert.True(t, (process.Memory.Rss.Bytes.ValueOr(0) > 0))
+	assert.True(t, process.Memory.Share.Exists())
 
 	// CPU Checks
 	assert.True(t, (process.CPU.Total.Value.ValueOr(0) >= 0))
-	assert.True(t, (process.CPU.User.Ticks.ValueOr(0) >= 0))   //nolint: staticcheck // it's not pointless in this case?
-	assert.True(t, (process.CPU.System.Ticks.ValueOr(0) >= 0)) //nolint: staticcheck // it's not pointless in this case?
+	assert.True(t, process.CPU.User.Ticks.Exists())
+	assert.True(t, process.CPU.System.Ticks.Exists())
 
 	assert.True(t, (process.SampleTime.Unix() <= time.Now().Unix()))
 


### PR DESCRIPTION
Along with the fix I have increased the threshold for `goconst` linter to 5.