### PR TITLE
Add CHANGELOG.md to repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+## [0.3.0]
+
+### Added
+
+- Add linux Hwmon reporting interface. #16
+- Add `filesystem` package. #17
+
+### Fixed
+
+- Fix build tags for `darwin` after refactoring of file handle metrics. #18
+- Fix process filtering. #19
+
+## [0.2.1]
+
+### Fixed
+
+- Fix package name for darwin in metrics setup. #15
+
+## [0.2.0]
+
+### Added
+
+- Add metrics reporting setup. #14
+
+## [0.1.0]
+
+### Added
+
+- First release of `github.come/elastic/elastic-agent-system-metrics`.
+
+[Unreleased]: https://github.com/elastic/elastic-agent-autodiscover/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/elastic/elastic-agent-autodiscover/compare/v0.0.0...v0.3.0
+[0.2.1]: https://github.com/elastic/elastic-agent-autodiscover/compare/v0.0.0...v0.2.1
+[0.2.0]: https://github.com/elastic/elastic-agent-autodiscover/compare/v0.0.0...v0.2.0
+[0.1.0]: https://github.com/elastic/elastic-agent-autodiscover/compare/v0.0.0...v0.1.0


### PR DESCRIPTION
This PR adds a CHANGELOG.md file, so we can track the changes in the repo. This commit also prepares for the new v0.3.0 release of the module.