### PR TITLE
Add `netbsd` an `openbsd` to build tags of `process_common.go`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Add more build tags to `process_common.go` so the module can be used on NetBSD and OpenBSD. #24
+
 ## [0.3.0]
 
 ### Added

--- a/metric/system/process/process_common.go
+++ b/metric/system/process/process_common.go
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build darwin || freebsd || linux || windows || aix
-// +build darwin freebsd linux windows aix
+//go:build darwin || freebsd || linux || windows || aix || netbsd || openbsd
+// +build darwin freebsd linux windows aix netbsd openbsd
 
 package process
 


### PR DESCRIPTION
## What does this PR do?

This PR adds `openbsd` and `freebsd` to the list of build tags protecting `process_common.go` file.

## Why is it important?

Without this change libbeat cannot be crosscompiled on openbsd and freebsd:

```
2 errors occurred:
 --> openbsd/amd64 error: exit status 2
 Stderr: # github.com/elastic/elastic-agent-system-metrics/metric/system/process
 ../../../../../pkg/mod/github.com/elastic/elastic-agent-system-metrics@v0.3.0/metric/system/process/process_types.go:32:11: undefined: PidState
 ../../../../../pkg/mod/github.com/elastic/elastic-agent-system-metrics@v0.3.0/metric/system/process/process_types.go:161:10: undefined: PidState

 --> netbsd/amd64 error: exit status 2
 Stderr: # github.com/elastic/elastic-agent-system-metrics/metric/system/process
 ../../../../../pkg/mod/github.com/elastic/elastic-agent-system-metrics@v0.3.0/metric/system/process/process_types.go:32:11: undefined: PidState
 ../../../../../pkg/mod/github.com/elastic/elastic-agent-system-metrics@v0.3.0/metric/system/process/process_types.go:161:10: undefined: PidState
```

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.md`

## Related issues

Required by https://github.com/elastic/beats/pull/31615

