### PR TITLE
Add uninterruptible disk sleep to system/process metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Move pacakges from Metricbeat: `internal/metrics/cpu` and `internal/metrics/memory`. #27
+- Add `D` process states. #32
 
 ### Changed
 

--- a/metric/system/process/process_common.go
+++ b/metric/system/process/process_common.go
@@ -79,8 +79,10 @@ var (
 	Running PidState = "running"
 	//Sleeping state
 	Sleeping PidState = "sleeping"
-	//Idle state. On linux this is "D"
+	//Idle state.
 	Idle PidState = "idle"
+	//DiskSleep is uninterruptible disk sleep
+	DiskSleep = "disk_sleep"
 	//Stopped state.
 	Stopped PidState = "stopped"
 	//Zombie state.
@@ -99,8 +101,8 @@ var (
 var PidStates = map[byte]PidState{
 	'S': Sleeping,
 	'R': Running,
-	'D': Idle, // Waiting in uninterruptible disk sleep, on some kernels this is marked as I below
-	'I': Idle, // in the scheduler, TASK_IDLE is defined as (TASK_UNINTERRUPTIBLE | TASK_NOLOAD)
+	'D': DiskSleep, // Waiting in uninterruptible disk sleep, on some kernels this is marked as I below
+	'I': Idle,      // in the scheduler, TASK_IDLE is defined as (TASK_UNINTERRUPTIBLE | TASK_NOLOAD)
 	'T': Stopped,
 	'Z': Zombie,
 	'X': Dead,

--- a/metric/system/process/process_common.go
+++ b/metric/system/process/process_common.go
@@ -82,7 +82,7 @@ var (
 	//Idle state.
 	Idle PidState = "idle"
 	//DiskSleep is uninterruptible disk sleep
-	DiskSleep = "disk_sleep"
+	DiskSleep PidState = "disk_sleep"
 	//Stopped state.
 	Stopped PidState = "stopped"
 	//Zombie state.


### PR DESCRIPTION
## What does this PR do?

This is a fix for https://github.com/elastic/beats/issues/20961

It differentiates between actual idle states and an uninterruptible disk sleep.

## Why is it important?

These are two different states, but we've always reported both as `idle`, for whatever reason.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`

