### PR TITLE
Move registry used by handles processor

### DIFF
--- a/report/setup.go
+++ b/report/setup.go
@@ -121,5 +121,5 @@ func setupPlatformSpecificMetrics(logger *logp.Logger, processStats *process.Sta
 		monitoring.NewFunc(systemMetrics, "load", ReportSystemLoadAverage, monitoring.Report)
 	}
 
-	SetupLinuxBSDFDMetrics(logger, systemMetrics, processStats)
+	SetupLinuxBSDFDMetrics(logger, processMetrics, processStats)
 }


### PR DESCRIPTION
## What does this PR do?

Fix for a bug reported by @cmacknz where the migration process of metrics from `libbeat` to here also changed the location of the `handles` monitoring metrics. This changes it back from `"system"` to `"beat"`. We don't have any tests here, so a tad hard to validate this until it makes its way up to the beats repo again.

## Checklist


- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`
