### PR TITLE
ci: enable orka m1 builds

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger("${obltGitHubComments()}")
+    issueCommentTrigger("(${obltGitHubComments()}|^/test all)")
   }
   stages {
     stage('Checkout') {
@@ -63,6 +63,21 @@ pipeline {
         }
         stages {
           stage('Test') {
+            when {
+              beforeAgent true
+              anyOf {
+                not { changeRequest() }
+                // As agreed macos M1 will be used in merge-commits
+                allOf {
+                  changeRequest()
+                  not {
+                    environment name: 'PLATFORM', value: 'darwin && orka && aarch64'
+                  }
+                }
+                // Allow to run on PRs if `/test all`
+                expression { return env.GITHUB_COMMENT?.contains('all') }
+              }
+            }
             steps {
               withGithubNotify(context: "Test-${PLATFORM}") {
                 deleteDir()

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
         axes {
           axis {
             name 'PLATFORM'
-            values 'ubuntu-20.04 && immutable', 'windows-2019 && windows-immutable', 'darwin && orka && x86_64'
+            values 'ubuntu-20.04 && immutable', 'windows-2019 && windows-immutable', 'darwin && orka && x86_64', 'darwin && orka && aarch64'
           }
         }
         stages {


### PR DESCRIPTION
## What does this PR do?

Run build/test in the CI on `macos m1` workers on `merge-commits` or `/test all` if a GitHub command

## Why is it important?

More test coverage

## Test

### Commits on a PR basis

<img width="864" alt="image" src="https://user-images.githubusercontent.com/2871786/189157736-6e906ee6-0206-4999-9e2e-8bfa6ec83dc1.png">

### When a github comment on a PR basis

<img width="983" alt="image" src="https://user-images.githubusercontent.com/2871786/189160148-0a7c3ae1-715f-4c42-8cba-ed4a53c984a0.png">

