### PR TITLE
Add IsZero to CPU Totals, report value for monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [0.4.3]
+
+## Fixed
+
+- Add IsZero to CPU Totals, report value for monitoring #40
+
 ## [0.4.2]
 
 ## Fixed

--- a/metric/system/process/helpers.go
+++ b/metric/system/process/helpers.go
@@ -94,7 +94,6 @@ func GetProcCPUPercentage(s0, s1 ProcState) ProcState {
 
 	s1.CPU.Total.Norm.Pct = opt.FloatWith(metric.Round(normalizedPct))
 	s1.CPU.Total.Pct = opt.FloatWith(metric.Round(pct))
-	s1.CPU.Total.Value = opt.FloatWith(metric.Round(float64(s1.CPU.Total.Ticks.ValueOr(0))))
 
 	return s1
 

--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -133,6 +133,8 @@ func (procStats *Stats) GetSelf() (ProcState, error) {
 	if err != nil {
 		return ProcState{}, fmt.Errorf("error fetching PID %d: %w", self, err)
 	}
+	// Copy Value over here, which would normally happen in system/process as part of percent calculation
+	pidStat.CPU.Total.Value = opt.FloatWith(float64(pidStat.CPU.Total.Ticks.ValueOr(0)))
 
 	return pidStat, nil
 }

--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -134,7 +134,7 @@ func (procStats *Stats) GetSelf() (ProcState, error) {
 	if err != nil {
 		return ProcState{}, fmt.Errorf("error fetching PID %d: %w", self, err)
 	}
-
+	procStats.ProcsMap[self] = pidStat
 	return pidStat, nil
 }
 

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -116,6 +117,22 @@ func TestProcessList(t *testing.T) {
 		assert.NotEmpty(t, proc.State)
 		assert.True(t, proc.Pid.Exists())
 	}
+}
+
+func TestSelfPersist(t *testing.T) {
+	stat, err := initTestResolver()
+	require.NoError(t, err, "Init()")
+	first, err := stat.GetSelf()
+	require.NoError(t, err, "First GetSelf()")
+
+	// The first process fetch shouldn't have percentages, since we don't have >1 procs to compare
+	assert.False(t, first.CPU.Total.Pct.Exists(), "total.pct should not exist")
+
+	second, err := stat.GetSelf()
+	require.NoError(t, err, "Second GetSelf()")
+
+	// now it should exist
+	assert.True(t, second.CPU.Total.Pct.Exists(), "total.pct should exist")
 }
 
 func TestGetProcess(t *testing.T) {

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -127,7 +127,7 @@ func TestSelfPersist(t *testing.T) {
 
 	// The first process fetch shouldn't have percentages, since we don't have >1 procs to compare
 	assert.False(t, first.CPU.Total.Pct.Exists(), "total.pct should not exist")
-
+	time.Sleep(time.Millisecond * 5)
 	second, err := stat.GetSelf()
 	require.NoError(t, err, "Second GetSelf()")
 
@@ -244,7 +244,6 @@ func TestProcCpuPercentage(t *testing.T) {
 
 	assert.EqualValues(t, 0.0721, normalizedTest)
 	assert.EqualValues(t, 3.459, newState.CPU.Total.Pct.ValueOr(0))
-	assert.EqualValues(t, 14841, newState.CPU.Total.Value.ValueOr(0))
 }
 
 // BenchmarkGetProcess runs a benchmark of the GetProcess method with caching

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -127,6 +127,7 @@ func TestSelfPersist(t *testing.T) {
 
 	// The first process fetch shouldn't have percentages, since we don't have >1 procs to compare
 	assert.False(t, first.CPU.Total.Pct.Exists(), "total.pct should not exist")
+	// Create a proper time delay so the CPU percentage delta calculations don't fail
 	time.Sleep(time.Millisecond * 5)
 	second, err := stat.GetSelf()
 	require.NoError(t, err, "Second GetSelf()")

--- a/metric/system/process/process_types.go
+++ b/metric/system/process/process_types.go
@@ -103,6 +103,10 @@ type ProcLimits struct {
 
 // Implementations
 
+func (t CPUTotal) IsZero() bool {
+	return t.Value.IsZero() && t.Ticks.IsZero() && t.Pct.IsZero() && t.Norm.IsZero()
+}
+
 // IsZero returns true if the underlying value nil
 func (t CPUTicks) IsZero() bool {
 	return t.Ticks.IsZero()


### PR DESCRIPTION
## What does this PR do?

This fixes three issues:

- Gives `CPUTotals` an `IsZero` method, so we don't report `{}` fields during certain events
- Fills out the `Value` field for `GetSelf()`, which is used by beats self-monitoring, and apparently that value is used by the `elastic_agent` dashboard.
- Make processes fetched with `GetSelf()` persist across calls

