### PR TITLE
fix thread safety in process code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix thread safety in process code #43
+
 ## [0.4.3]
 
 ## Fixed

--- a/metric/system/process/process_common.go
+++ b/metric/system/process/process_common.go
@@ -23,6 +23,7 @@ package process
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/match"
@@ -33,8 +34,42 @@ import (
 	sysinfo "github.com/elastic/go-sysinfo"
 )
 
-// ProcsMap is a map where the keys are the names of processes and the value is the Process with that name
+//ProcsMap is aconvinence wrapper type
 type ProcsMap map[int]ProcState
+
+// ProcsTrack is a map where the keys are the names of processes and the value is the Process with that name
+//type ProcsTrack map[int]ProcState
+type ProcsTrack struct {
+	pids ProcsMap
+	mut  *sync.Mutex
+}
+
+func NewProcsMap() *ProcsTrack {
+	return &ProcsTrack{
+		pids: make(ProcsMap, 0),
+		mut:  &sync.Mutex{},
+	}
+}
+
+func (pm *ProcsTrack) GetPid(pid int) (ProcState, bool) {
+	pm.mut.Lock()
+	defer pm.mut.Unlock()
+	proc, ok := pm.pids[pid]
+	return proc, ok
+}
+
+func (pm *ProcsTrack) SetPid(pid int, ps ProcState) {
+	pm.mut.Lock()
+	defer pm.mut.Unlock()
+	pm.pids[pid] = ps
+}
+
+func (pm *ProcsTrack) SetMap(pids map[int]ProcState) {
+	pm.mut.Lock()
+	defer pm.mut.Unlock()
+	pm.pids = pids
+
+}
 
 // ProcCallback is a function that FetchPid* methods can call at various points to do OS-agnostic processing
 type ProcCallback func(in ProcState) (ProcState, error)
@@ -53,7 +88,7 @@ type CgroupPctStats struct {
 type Stats struct {
 	Hostfs        resolve.Resolver
 	Procs         []string
-	ProcsMap      ProcsMap
+	ProcsMap      *ProcsTrack
 	CPUTicks      bool
 	EnvWhitelist  []string
 	CacheCmdLine  bool
@@ -128,7 +163,7 @@ func (procStats *Stats) Init() error {
 		procStats.Hostfs = resolve.NewTestResolver("/")
 	}
 
-	procStats.ProcsMap = make(ProcsMap)
+	procStats.ProcsMap = NewProcsMap()
 
 	if len(procStats.Procs) == 0 {
 		return nil

--- a/metric/system/process/process_common.go
+++ b/metric/system/process/process_common.go
@@ -34,20 +34,19 @@ import (
 	sysinfo "github.com/elastic/go-sysinfo"
 )
 
-//ProcsMap is aconvinence wrapper type
+//ProcsMap is a convinence wrapper for the oft-used ideom of map[int]ProcState
 type ProcsMap map[int]ProcState
 
-// ProcsTrack is a map where the keys are the names of processes and the value is the Process with that name
-//type ProcsTrack map[int]ProcState
+// ProcsTrack is a thread-safe wrapper for a process Stat object's internal map of processes.
 type ProcsTrack struct {
 	pids ProcsMap
-	mut  *sync.Mutex
+	mut  sync.Mutex
 }
 
 func NewProcsMap() *ProcsTrack {
 	return &ProcsTrack{
 		pids: make(ProcsMap, 0),
-		mut:  &sync.Mutex{},
+		mut:  sync.Mutex{},
 	}
 }
 

--- a/metric/system/process/process_common.go
+++ b/metric/system/process/process_common.go
@@ -40,19 +40,18 @@ type ProcsMap map[int]ProcState
 // ProcsTrack is a thread-safe wrapper for a process Stat object's internal map of processes.
 type ProcsTrack struct {
 	pids ProcsMap
-	mut  sync.Mutex
+	mut  sync.RWMutex
 }
 
-func NewProcsMap() *ProcsTrack {
+func NewProcsTrack() *ProcsTrack {
 	return &ProcsTrack{
 		pids: make(ProcsMap, 0),
-		mut:  sync.Mutex{},
 	}
 }
 
 func (pm *ProcsTrack) GetPid(pid int) (ProcState, bool) {
-	pm.mut.Lock()
-	defer pm.mut.Unlock()
+	pm.mut.RLock()
+	defer pm.mut.RUnlock()
 	proc, ok := pm.pids[pid]
 	return proc, ok
 }
@@ -162,7 +161,7 @@ func (procStats *Stats) Init() error {
 		procStats.Hostfs = resolve.NewTestResolver("/")
 	}
 
-	procStats.ProcsMap = NewProcsMap()
+	procStats.ProcsMap = NewProcsTrack()
 
 	if len(procStats.Procs) == 0 {
 		return nil

--- a/metric/system/process/process_linux_common.go
+++ b/metric/system/process/process_linux_common.go
@@ -59,7 +59,7 @@ func (procStats *Stats) FetchPids() (ProcsMap, []ProcState, error) {
 		return nil, nil, fmt.Errorf("error reading directory names: %w", err)
 	}
 
-	procMap := make(ProcsMap, 0)
+	procMap := make(ProcsMap)
 	var plist []ProcState
 
 	// Iterate over the directory, fetch just enough info so we can filter based on user input.

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -206,7 +206,7 @@ func TestProcMemPercentage(t *testing.T) {
 		},
 	}
 
-	procStats.ProcsMap = NewProcsMap()
+	procStats.ProcsMap = NewProcsTrack()
 	procStats.ProcsMap.SetPid(p.Pid.ValueOr(0), p)
 
 	rssPercent := GetProcMemPercentage(p, 10000)

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -206,8 +206,8 @@ func TestProcMemPercentage(t *testing.T) {
 		},
 	}
 
-	procStats.ProcsMap = make(ProcsMap)
-	procStats.ProcsMap[p.Pid.ValueOr(0)] = p
+	procStats.ProcsMap = NewProcsMap()
+	procStats.ProcsMap.SetPid(p.Pid.ValueOr(0), p)
 
 	rssPercent := GetProcMemPercentage(p, 10000)
 	assert.Equal(t, rssPercent.ValueOr(0), 0.1416)

--- a/report/metrics_report_test.go
+++ b/report/metrics_report_test.go
@@ -37,17 +37,12 @@ func TestSystemMetricsReport(t *testing.T) {
 	var gotCPU, gotMem, gotInfo bool
 	testFunc := func(key string, val interface{}) {
 		if key == "info.uptime.ms" {
-			uptime, ok := val.(int64)
-			assert.True(t, ok, "info.uptime.ms not an int64")
-			assert.NotZero(t, uptime, "error fetching info.uptime.ms")
 			gotInfo = true
 		}
 		if key == "cpu.total.ticks" {
-			assert.NotNil(t, val)
 			gotCPU = true
 		}
 		if key == "memstats.rss" {
-			assert.NotNil(t, val)
 			gotMem = true
 		}
 	}

--- a/report/metrics_report_test.go
+++ b/report/metrics_report_test.go
@@ -50,15 +50,18 @@ func TestSystemMetricsReport(t *testing.T) {
 	//iterate over the processes a few times,
 	// with the concurrency (hopefully) emulating what might
 	// happen if this was an HTTP endpoint getting multiple GET requests
-	iter := 5
+	iter := 100
 	var wait sync.WaitGroup
 	wait.Add(iter)
+	ch := make(chan struct{})
 	for i := 0; i < iter; i++ {
 		go func() {
+			<-ch
 			processMetrics.Do(monitoring.Full, testFunc)
 			wait.Done()
 		}()
 	}
+	close(ch)
 
 	wait.Wait()
 	assert.True(t, gotCPU, "Didn't find cpu.total.ticks")

--- a/report/metrics_report_test.go
+++ b/report/metrics_report_test.go
@@ -1,0 +1,72 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package report
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
+
+func TestSystemMetricsReport(t *testing.T) {
+	_ = logp.DevelopmentSetup()
+	logger := logp.L()
+	err := SetupMetrics(logger, "TestSys", "test")
+	require.NoError(t, err)
+
+	var gotCPU, gotMem, gotInfo bool
+	testFunc := func(key string, val interface{}) {
+		if key == "info.uptime.ms" {
+			uptime, ok := val.(int64)
+			assert.True(t, ok, "info.uptime.ms not an int64")
+			assert.NotZero(t, uptime, "error fetching info.uptime.ms")
+			gotInfo = true
+		}
+		if key == "cpu.total.ticks" {
+			assert.NotNil(t, val)
+			gotCPU = true
+		}
+		if key == "memstats.rss" {
+			assert.NotNil(t, val)
+			gotMem = true
+		}
+	}
+
+	//iterate over the processes a few times,
+	// with the concurrency (hopefully) emulating what might
+	// happen if this was an HTTP endpoint getting multiple GET requests
+	iter := 5
+	var wait sync.WaitGroup
+	wait.Add(iter)
+	for i := 0; i < iter; i++ {
+		go func() {
+			processMetrics.Do(monitoring.Full, testFunc)
+			wait.Done()
+		}()
+	}
+
+	wait.Wait()
+	assert.True(t, gotCPU, "Didn't find cpu.total.ticks")
+	assert.True(t, gotMem, "Didn't find memstats.rss")
+	assert.True(t, gotInfo, "Didn't find info.uptime.ms")
+}


### PR DESCRIPTION
## What does this PR do?

This fixes https://github.com/elastic/beats/issues/32467

This code originates from metricbeat, which never worried too much about threadsafety, since a single metricset just lives in its own thread. However, the code has carried over to beat's self-monitoring in `report/`. A previous PR fixed a bug where `GetSelf()` would not calculate percentages, as it never accessed its own internal map of processes that it uses to calculate percentages. However, `setup.go` was creating a single instance of the process `Stat` struct to send to multiple function callbacks in the monitoring, hence a concurrent map access. 

Wanted to get this PR up fast, still testing on non-linux systems.

## Why is it important?

Potential concurrent hashmap access issue.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added an entry in `CHANGELOG.md`
- [x] Test on darwin
- [ ] Test on Windows
