### PR TITLE
Add Process State API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901
 	github.com/magefile/mage v1.13.0
+	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/shirou/gopsutil/v3 v3.21.12
 	github.com/stretchr/testify v1.7.0
 	go.elastic.co/go-licence-detector v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -365,6 +365,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
+github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil/v3 v3.21.12 h1:VoGxEW2hpmz0Vt3wUvHIl9fquzYLNpVpgNNB7pGJimA=
 github.com/shirou/gopsutil/v3 v3.21.12/go.mod h1:BToYZVTlSVlfazpDDYFnsVZLaoRG+g8ufT6fPQLdJzA=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -21,11 +21,14 @@
 package process
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sort"
 	"strings"
 	"time"
+
+	psutil "github.com/shirou/gopsutil/process"
 
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/opt"
@@ -54,6 +57,27 @@ func ListStates(hostfs resolve.Resolver) ([]ProcState, error) {
 	}
 
 	return plist, nil
+}
+
+// GetPIDState returns the state of a given PID
+// It will return ProcNotExist if the process was not found.
+func GetPIDState(hostfs resolve.Resolver, pid int) (PidState, error) {
+	// This library still doesn't have a good cross-platform way to distinguish between "does not eixst" and other process errors.
+	// This is a fairly difficult problem to solve in a cross-platform way
+	exists, err := psutil.PidExistsWithContext(context.Background(), int32(pid))
+	if err != nil {
+		return "", fmt.Errorf("Error truing to find process: %d: %w", pid, err)
+	}
+	if !exists {
+		return "", ProcNotExist
+	}
+	//GetInfoForPid will return the smallest possible dataset for a PID
+	procState, err := GetInfoForPid(hostfs, pid)
+	if err != nil {
+		return "", fmt.Errorf("error getting state info for pid %d: %w", pid, err)
+	}
+
+	return procState.State, nil
 }
 
 // Get fetches the configured processes and returns a list of formatted events and root ECS fields

--- a/metric/system/process/process_common.go
+++ b/metric/system/process/process_common.go
@@ -34,6 +34,9 @@ import (
 	sysinfo "github.com/elastic/go-sysinfo"
 )
 
+// ProcNotExist indicates that a process was not found.
+var ProcNotExist = errors.New("Process does not exist")
+
 //ProcsMap is a convinence wrapper for the oft-used ideom of map[int]ProcState
 type ProcsMap map[int]ProcState
 

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -38,6 +38,13 @@ import (
 	"github.com/elastic/elastic-agent-system-metrics/metric/system/resolve"
 )
 
+func TestGetState(t *testing.T) {
+	// Getpid is really the only way to test this in a cross-platform way
+	state, err := GetPIDState(resolve.NewTestResolver("/"), os.Getpid())
+	require.NoError(t, err)
+	require.Equal(t, Running, state)
+}
+
 func TestGetOne(t *testing.T) {
 	testConfig := Stats{
 		Procs:        []string{".*"},


### PR DESCRIPTION
## What does this PR do?

This is part of https://github.com/elastic/beats/pull/33169

Specifically, This adds a public API that reports the state of a given PID, and a special error if a given process does not exist.

This is a bit of an awkward fix, since there's no "good" place for this API to go; This library is mainly for handling the complexities of the `system/process` dataset, but it's only the library we have that reports process state. `go-sysinfo` might be a better fit for this, but there's no code for fetching process state there. So, for now, this is kind of the best we can do.

## Why is it important?

This is needed by https://github.com/elastic/beats/pull/33169 so we can distinguish between zombie processes and other process types.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`
