### PR TITLE
Move exported helpers to process_common.go file

### DIFF
--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -21,64 +21,17 @@
 package process
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"sort"
 	"strings"
 	"time"
 
-	psutil "github.com/shirou/gopsutil/process"
-
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/opt"
 	"github.com/elastic/elastic-agent-libs/transform/typeconv"
 	"github.com/elastic/elastic-agent-system-metrics/metric"
-	"github.com/elastic/elastic-agent-system-metrics/metric/system/resolve"
 )
-
-// ListStates is a wrapper that returns a list of processess with only the basic PID info filled out.
-func ListStates(hostfs resolve.Resolver) ([]ProcState, error) {
-	init := Stats{
-		Hostfs:        hostfs,
-		Procs:         []string{".*"},
-		EnableCgroups: false,
-		skipExtended:  true,
-	}
-	err := init.Init()
-	if err != nil {
-		return nil, fmt.Errorf("error initializing process collectors: %w", err)
-	}
-
-	// actually fetch the PIDs from the OS-specific code
-	_, plist, err := init.FetchPids()
-	if err != nil {
-		return nil, fmt.Errorf("error gathering PIDs: %w", err)
-	}
-
-	return plist, nil
-}
-
-// GetPIDState returns the state of a given PID
-// It will return ProcNotExist if the process was not found.
-func GetPIDState(hostfs resolve.Resolver, pid int) (PidState, error) {
-	// This library still doesn't have a good cross-platform way to distinguish between "does not eixst" and other process errors.
-	// This is a fairly difficult problem to solve in a cross-platform way
-	exists, err := psutil.PidExistsWithContext(context.Background(), int32(pid))
-	if err != nil {
-		return "", fmt.Errorf("Error trying to find process: %d: %w", pid, err)
-	}
-	if !exists {
-		return "", ProcNotExist
-	}
-	//GetInfoForPid will return the smallest possible dataset for a PID
-	procState, err := GetInfoForPid(hostfs, pid)
-	if err != nil {
-		return "", fmt.Errorf("error getting state info for pid %d: %w", pid, err)
-	}
-
-	return procState.State, nil
-}
 
 // Get fetches the configured processes and returns a list of formatted events and root ECS fields
 func (procStats *Stats) Get() ([]mapstr.M, []mapstr.M, error) {

--- a/metric/system/process/process_common.go
+++ b/metric/system/process/process_common.go
@@ -21,6 +21,7 @@
 package process
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -32,6 +33,7 @@ import (
 	"github.com/elastic/go-sysinfo/types"
 
 	sysinfo "github.com/elastic/go-sysinfo"
+	psutil "github.com/shirou/gopsutil/process"
 )
 
 // ProcNotExist indicates that a process was not found.
@@ -199,4 +201,47 @@ func (procStats *Stats) Init() error {
 		procStats.cgroups = cgReader
 	}
 	return nil
+}
+
+// ListStates is a wrapper that returns a list of processess with only the basic PID info filled out.
+func ListStates(hostfs resolve.Resolver) ([]ProcState, error) {
+	init := Stats{
+		Hostfs:        hostfs,
+		Procs:         []string{".*"},
+		EnableCgroups: false,
+		skipExtended:  true,
+	}
+	err := init.Init()
+	if err != nil {
+		return nil, fmt.Errorf("error initializing process collectors: %w", err)
+	}
+
+	// actually fetch the PIDs from the OS-specific code
+	_, plist, err := init.FetchPids()
+	if err != nil {
+		return nil, fmt.Errorf("error gathering PIDs: %w", err)
+	}
+
+	return plist, nil
+}
+
+// GetPIDState returns the state of a given PID
+// It will return ProcNotExist if the process was not found.
+func GetPIDState(hostfs resolve.Resolver, pid int) (PidState, error) {
+	// This library still doesn't have a good cross-platform way to distinguish between "does not eixst" and other process errors.
+	// This is a fairly difficult problem to solve in a cross-platform way
+	exists, err := psutil.PidExistsWithContext(context.Background(), int32(pid))
+	if err != nil {
+		return "", fmt.Errorf("Error truing to find process: %d: %w", pid, err)
+	}
+	if !exists {
+		return "", ProcNotExist
+	}
+	//GetInfoForPid will return the smallest possible dataset for a PID
+	procState, err := GetInfoForPid(hostfs, pid)
+	if err != nil {
+		return "", fmt.Errorf("error getting state info for pid %d: %w", pid, err)
+	}
+
+	return procState.State, nil
 }


### PR DESCRIPTION
## What does this PR do?

So, this is to help along the CI in https://github.com/elastic/beats/pull/33169

Specifically, the github CI has cgo disabled, and the main `process.go` file has a build requirement of `darwin & cgo`

So, this moves the two exported "helper" functions to `process_common.go` as they don't actually need any build constraints, and they don't really fit with everything else in the `process.go` file.

I'm not 100% sure _why_ the `process.go` file has a build constraint on darwin and cgo, but considering that this is part of a bugfix that's get backported post-FF, I'm reluctant to go tinkering around in build logic.


## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have added an entry in `CHANGELOG.md`
