### PR TITLE
Revert "move exported helpers to _common.go file"

### DIFF
--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -21,17 +21,64 @@
 package process
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sort"
 	"strings"
 	"time"
 
+	psutil "github.com/shirou/gopsutil/process"
+
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/opt"
 	"github.com/elastic/elastic-agent-libs/transform/typeconv"
 	"github.com/elastic/elastic-agent-system-metrics/metric"
+	"github.com/elastic/elastic-agent-system-metrics/metric/system/resolve"
 )
+
+// ListStates is a wrapper that returns a list of processess with only the basic PID info filled out.
+func ListStates(hostfs resolve.Resolver) ([]ProcState, error) {
+	init := Stats{
+		Hostfs:        hostfs,
+		Procs:         []string{".*"},
+		EnableCgroups: false,
+		skipExtended:  true,
+	}
+	err := init.Init()
+	if err != nil {
+		return nil, fmt.Errorf("error initializing process collectors: %w", err)
+	}
+
+	// actually fetch the PIDs from the OS-specific code
+	_, plist, err := init.FetchPids()
+	if err != nil {
+		return nil, fmt.Errorf("error gathering PIDs: %w", err)
+	}
+
+	return plist, nil
+}
+
+// GetPIDState returns the state of a given PID
+// It will return ProcNotExist if the process was not found.
+func GetPIDState(hostfs resolve.Resolver, pid int) (PidState, error) {
+	// This library still doesn't have a good cross-platform way to distinguish between "does not eixst" and other process errors.
+	// This is a fairly difficult problem to solve in a cross-platform way
+	exists, err := psutil.PidExistsWithContext(context.Background(), int32(pid))
+	if err != nil {
+		return "", fmt.Errorf("Error trying to find process: %d: %w", pid, err)
+	}
+	if !exists {
+		return "", ProcNotExist
+	}
+	//GetInfoForPid will return the smallest possible dataset for a PID
+	procState, err := GetInfoForPid(hostfs, pid)
+	if err != nil {
+		return "", fmt.Errorf("error getting state info for pid %d: %w", pid, err)
+	}
+
+	return procState.State, nil
+}
 
 // Get fetches the configured processes and returns a list of formatted events and root ECS fields
 func (procStats *Stats) Get() ([]mapstr.M, []mapstr.M, error) {


### PR DESCRIPTION
This reverts commit eb54ad9a98dcd27da23331d41910a5c738edb303.

That change was made while fighting with the CI issues in https://github.com/elastic/beats/pull/33169

We eventually made a different (admittedly still kinda ugly) workaround, rendering this change unnecessary, and I think it may cause issues on Darwin.
