### PR TITLE
system/process fixes on AIX

### DIFF
--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -24,8 +24,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	psutil "github.com/shirou/gopsutil/process"
@@ -62,6 +64,23 @@ func ListStates(hostfs resolve.Resolver) ([]ProcState, error) {
 // GetPIDState returns the state of a given PID
 // It will return ProcNotExist if the process was not found.
 func GetPIDState(hostfs resolve.Resolver, pid int) (PidState, error) {
+	// As psutils doesn't support AIX, we use GetInfoForPid directly.
+	// It returns an ESRCH if no process is found.
+	if runtime.GOOS == "aix" {
+		state, err := GetInfoForPid(hostfs, pid)
+		if err == syscall.ESRCH {
+			// We assume that syscall.ESRCH is mapped for all GOOS
+			// this package is compiled for. If not, we will have to give this
+			// to a build-flag controlled function to check.
+			return "", ProcNotExist
+		}
+		if err != nil {
+			return "", fmt.Errorf("error getting PID info for %d: %w", pid, err)
+		}
+
+		return state.State, nil
+	}
+
 	// This library still doesn't have a good cross-platform way to distinguish between "does not eixst" and other process errors.
 	// This is a fairly difficult problem to solve in a cross-platform way
 	exists, err := psutil.PidExistsWithContext(context.Background(), int32(pid))
@@ -71,6 +90,7 @@ func GetPIDState(hostfs resolve.Resolver, pid int) (PidState, error) {
 	if !exists {
 		return "", ProcNotExist
 	}
+
 	//GetInfoForPid will return the smallest possible dataset for a PID
 	procState, err := GetInfoForPid(hostfs, pid)
 	if err != nil {

--- a/metric/system/process/process_aix.go
+++ b/metric/system/process/process_aix.go
@@ -155,8 +155,11 @@ func FillPidMetrics(_ resolve.Resolver, pid int, state ProcState, filter func(st
 
 		args = append(args, stripNullByte(arg))
 	}
+
 	state.Args = args
-	state.Exe = args[0]
+	if len(args) > 0 {
+		state.Exe = args[0]
+	}
 
 	// get env vars
 	buf = make([]byte, 8192)

--- a/metric/system/process/process_aix.go
+++ b/metric/system/process/process_aix.go
@@ -48,7 +48,6 @@ func (procStats *Stats) FetchPids() (ProcsMap, []ProcState, error) {
 	procMap := make(ProcsMap, 0)
 	var plist []ProcState
 	for {
-		// getprocs first argument is a void*
 		num, err := C.getprocs(unsafe.Pointer(&info), C.sizeof_struct_procsinfo64, nil, 0, &pid, 1)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error fetching PIDs: %w", err)
@@ -62,16 +61,54 @@ func (procStats *Stats) FetchPids() (ProcsMap, []ProcState, error) {
 	return procMap, plist, nil
 }
 
+// procExists returns true if a process is present in the AIX process table
+func procExists(pid int) (bool, error) {
+	info := [20]C.struct_procsinfo64{}
+	idxPtr := C.pid_t(0)
+
+	for {
+		num, err := C.getprocs(unsafe.Pointer(&info), C.sizeof_struct_procsinfo64, nil, 0, &idxPtr, 20)
+		if err != nil {
+			return false, fmt.Errorf("error fetching PID at IndexPointer %d: %w", int(idxPtr), err)
+		}
+
+		if num == 0 {
+			break
+		}
+
+		for i := 0; i < len(info); i++ {
+			if int(info[i].pi_pid) == pid {
+				return true, nil
+			}
+		}
+
+	}
+
+	return false, nil
+}
+
 // GetInfoForPid returns basic info for the process
 func GetInfoForPid(_ resolve.Resolver, pid int) (ProcState, error) {
 	info := C.struct_procsinfo64{}
 	cpid := C.pid_t(pid)
 
+	// getprocs uses an IndexPointer, which doesn't need to correlate in every case to the PID
+	// but here we fetch a count of 1 procs and therefore it should match it.
 	num, err := C.getprocs(unsafe.Pointer(&info), C.sizeof_struct_procsinfo64, nil, 0, &cpid, 1)
 	if err != nil {
 		return ProcState{}, fmt.Errorf("error in getprocs: %w", err)
 	}
 	if num != 1 {
+		return ProcState{}, syscall.ESRCH
+	}
+
+	// Since getprocs can return a proccess with pi_state=Running which is already
+	// dead, we need to check if it really exist.
+	ok, err := procExists(pid)
+	if err != nil {
+		return ProcState{}, fmt.Errorf("error in procExists: %w", err)
+	}
+	if !ok {
 		return ProcState{}, syscall.ESRCH
 	}
 
@@ -109,12 +146,16 @@ func GetInfoForPid(_ resolve.Resolver, pid int) (ProcState, error) {
 	return state, nil
 }
 
-// FillPidMetrics is the aix implementation
+// FillPidMetrics is the aix implementation. If the process died in the meantime and is still present in the
+// process table, this call still succeeds.
 func FillPidMetrics(_ resolve.Resolver, pid int, state ProcState, filter func(string) bool) (ProcState, error) {
 	pagesize := uint64(os.Getpagesize())
 	info := C.struct_procsinfo64{}
 	cpid := C.pid_t(pid)
 
+	// getprocs uses an IndexPointer, which doesn't need to correlate in every case to the PID
+	// but here we fetch a count of 1 procs and therefore it should match it.
+	// A dead process could still be looked up when directly using the IndexPointer as pid.
 	num, err := C.getprocs(unsafe.Pointer(&info), C.sizeof_struct_procsinfo64, nil, 0, &cpid, 1)
 	if err != nil {
 		return state, fmt.Errorf("error in getprocs: %w", err)

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build darwin || freebsd || linux || windows
-// +build darwin freebsd linux windows
+//go:build darwin || freebsd || linux || windows || aix
+// +build darwin freebsd linux windows aix
 
 package process
 


### PR DESCRIPTION
To be labelled:
- Bug
- Enhancement

## What does this PR do?
It makes system/process usable on AIX. The preparation of this package for AIX was already done but in it's current state it's not usable for metricbeat.

The following things were done:
- GetPIDState was implemented for AIX as currently it was returning a "not implemented" from psutils
- Function procExists was implemented as the usage of GetInfoForPid isn't suitable to detect if a process still exists and can lead to errors. For example metricbeat couldn't handle lock files on AIX. #60 
- A bug was fixed where in special cases (e.g. pid 0) no exe is parsable from cmdargs which caused out of range errors
- system/process tests were activated on AIX

## Why is it important?
metricbeat is mostly prepared for AIX but it isn't completely working because of bugs like this or lacking features like #58 
This PR ensures that a current metricbeat version is still buildable and usable on AIX. 

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues
- Closes #60
- Relates #58 
