### PR TITLE
Add per-process network stats

### DIFF
--- a/metric/system/network/helpers_test.go
+++ b/metric/system/network/helpers_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package network
 
 import (

--- a/metric/system/network/helpers_test.go
+++ b/metric/system/network/helpers_test.go
@@ -1,0 +1,43 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/elastic/go-sysinfo/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilter(t *testing.T) {
+	exampleData := &types.NetworkCountersInfo{SNMP: types.SNMP{
+		IP: map[string]uint64{"DefaultTTL": 0x40, "ForwDatagrams": 0x3ef68, "Forwarding": 0x1, "FragCreates": 0x0, "FragFails": 0x0, "FragOKs": 0x0, "InAddrErrors": 0x2,
+			"InDelivers": 0x132b5d, "InReceives": 0x1904f4, "InUnknownProtos": 0x0, "OutDiscards": 0x0, "OutNoRoutes": 0xe,
+			"OutRequests": 0x143a7e},
+		ICMP:    map[string]uint64{"InAddrMaskReps": 0x0},
+		ICMPMsg: map[string]uint64{"InType3": 0x2, "OutType3": 0x85},
+		TCP: map[string]uint64{"ActiveOpens": 0x63d, "AttemptFails": 0x72, "CurrEstab": 0x9, "EstabResets": 0x54, "InCsumErrors": 0x0, "InErrs": 0x0, "InSegs": 0x13270b,
+			"MaxConn": 0xffffffffffffffff, "OutRsts": 0x2f6, "OutSegs": 0x111424},
+		UDP:     map[string]uint64{"NoPorts": 0x1, "OutDatagrams": 0x4d5},
+		UDPLite: map[string]uint64{"SndbufErrors": 0x0},
+	},
+		Netstat: types.Netstat{
+			TCPExt: map[string]uint64{"TCPAbortOnClose": 0x6, "TCPAbortOnData": 0x51, "TCPAbortOnLinger": 0x0, "TCPAbortOnMemory": 0x0,
+				"TCPAbortOnTimeout": 0x7f, "TCPAckCompressed": 0x3346, "TCPAutoCorking": 0x1063, "TCPBacklogCoalesce": 0x38a, "TCPBacklogDrop": 0x0, "TCPChallengeACK": 0x0, "TCPDSACKIgnoredDubious": 0x0,
+				"TCPHPHits": 0x99fc8, "TCPHystartDelayCwnd": 0x294, "TCPHystartDelayDetect": 0x3, "TCPHystartTrainCwnd": 0xa1e},
+			IPExt: map[string]uint64{"InBcastOctets": 0x514d4c, "InBcastPkts": 0x1e999, "InCEPkts": 0x0, "InCsumErrors": 0x0, "InECT0Pkts": 0x0, "InECT1Pkts": 0x0, "InMcastOctets": 0x44a,
+				"InMcastPkts": 0x12, "InNoECTPkts": 0x1ec6d9, "InNoRoutes": 0x0, "InOctets": 0x50701313, "OutMcastPkts": 0x71, "OutOctets": 0x47f14f8c, "ReasmOverlaps": 0x0},
+		},
+	}
+	// test with no filter
+	testAll := []string{"all"}
+	allMap := MapProcNetCountersWithFilter(exampleData, testAll)
+	require.Equal(t, len(exampleData.SNMP.ICMP)+len(exampleData.SNMP.ICMPMsg), len(allMap["icmp"].(map[string]interface{})))
+	require.Equal(t, len(exampleData.SNMP.TCP)+len(exampleData.Netstat.TCPExt), len(allMap["tcp"].(map[string]interface{})))
+
+	//test With filter
+	testTwo := []string{"TCPAbortOnClose", "InBcastOctets"}
+	filteredMap := MapProcNetCountersWithFilter(exampleData, testTwo)
+	require.Equal(t, 1, len(filteredMap["tcp"].(map[string]interface{})))
+	require.Equal(t, uint64(0x6), filteredMap["tcp"].(map[string]interface{})["TCPAbortOnClose"])
+
+	require.Equal(t, uint64(0x514d4c), filteredMap["ip"].(map[string]interface{})["InBcastOctets"])
+}

--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -284,7 +284,7 @@ func (procStats *Stats) getProcessEvent(process *ProcState) (mapstr.M, error) {
 	err := typeconv.Convert(&proc, process)
 
 	if procStats.EnableNetwork && process.Network != nil {
-		proc["network"] = network.MapProcNetCounters(process.Network)
+		proc["network"] = network.MapProcNetCountersWithFilter(process.Network, procStats.NetworkMetrics)
 	}
 
 	return proc, err

--- a/metric/system/process/process_common.go
+++ b/metric/system/process/process_common.go
@@ -97,6 +97,9 @@ type Stats struct {
 	CgroupOpts    cgroup.ReaderOptions
 	EnableCgroups bool
 	EnableNetwork bool
+	// NetworkMetrics is an allowlist of network metrics,
+	// the names of which can be found in /proc/PID/net/snmp and /proc/PID/net/netstat
+	NetworkMetrics []string
 
 	skipExtended bool
 	procRegexps  []match.Matcher // List of regular expressions used to whitelist processes.
@@ -166,8 +169,12 @@ func (procStats *Stats) Init() error {
 	}
 
 	if procStats.EnableNetwork && procStats.Hostfs.IsSet() {
-		procStats.logger.Warnf("hostfs has been set to %s, and EnableNetwork has been set, but per-process network counters are currently not supported with an alternate filesystem", procStats.Hostfs.ResolveHostFS(""))
+		procStats.logger.Warnf("hostfs has been set to %s, and EnableNetwork has been set, but per-process network counters are currently not supported with an alternate filesystem.", procStats.Hostfs.ResolveHostFS(""))
 		procStats.EnableNetwork = false
+	}
+
+	if procStats.EnableNetwork && len(procStats.NetworkMetrics) == 0 {
+		procStats.logger.Warnf("Collecting all network metrics per-process; this will produce a large volume of data.")
 	}
 
 	procStats.ProcsMap = NewProcsTrack()

--- a/metric/system/process/process_common.go
+++ b/metric/system/process/process_common.go
@@ -96,6 +96,7 @@ type Stats struct {
 	IncludeTop    IncludeTopConfig
 	CgroupOpts    cgroup.ReaderOptions
 	EnableCgroups bool
+	EnableNetwork bool
 
 	skipExtended bool
 	procRegexps  []match.Matcher // List of regular expressions used to whitelist processes.
@@ -162,6 +163,11 @@ func (procStats *Stats) Init() error {
 	//footcannon prevention
 	if procStats.Hostfs == nil {
 		procStats.Hostfs = resolve.NewTestResolver("/")
+	}
+
+	if procStats.EnableNetwork && procStats.Hostfs.IsSet() {
+		procStats.logger.Warnf("hostfs has been set to %s, and EnableNetwork has been set, but per-process network counters are currently not supported with an alternate filesystem", procStats.Hostfs.ResolveHostFS(""))
+		procStats.EnableNetwork = false
 	}
 
 	procStats.ProcsMap = NewProcsTrack()

--- a/metric/system/process/process_types.go
+++ b/metric/system/process/process_types.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/opt"
 	"github.com/elastic/elastic-agent-system-metrics/metric/system/cgroup"
+	sysinfotypes "github.com/elastic/go-sysinfo/types"
 )
 
 // ProcState is the main struct for process information and metrics.
@@ -43,9 +44,10 @@ type ProcState struct {
 	Env     mapstr.M `struct:"env,omitempty"`
 
 	// Resource Metrics
-	Memory ProcMemInfo `struct:"memory,omitempty"`
-	CPU    ProcCPUInfo `struct:"cpu,omitempty"`
-	FD     ProcFDInfo  `struct:"fd,omitempty"`
+	Memory  ProcMemInfo                       `struct:"memory,omitempty"`
+	CPU     ProcCPUInfo                       `struct:"cpu,omitempty"`
+	FD      ProcFDInfo                        `struct:"fd,omitempty"`
+	Network *sysinfotypes.NetworkCountersInfo `struct:"-,omitempty"`
 
 	// cgroups
 	Cgroup cgroup.CGStats `struct:"cgroup,omitempty"`


### PR DESCRIPTION
## What does this PR do?
This is one half of https://github.com/elastic/beats/issues/7461

This adds per-process network stats on linux, taken from `/proc/PID/net/netstat` and `/proc/PID/net/SNMP`. 
These metrics are the same kind used in the docker module for reporting docker network summary data.

This also includes a filter function, since all the data in the aforementioned two procfs files includes a prodigious amount of metrics.

There's a notable limitation here, which is that the procfs handler we're importing from `go-sysinfo` can't handle an alternate procfs.

## Why is it important?

This is an asked-for feature.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`
