### PR TITLE
Remove hostfs checks

### DIFF
--- a/metric/system/process/process_common.go
+++ b/metric/system/process/process_common.go
@@ -168,11 +168,6 @@ func (procStats *Stats) Init() error {
 		procStats.Hostfs = resolve.NewTestResolver("/")
 	}
 
-	if procStats.EnableNetwork && procStats.Hostfs.IsSet() {
-		procStats.logger.Warnf("hostfs has been set to %s, and EnableNetwork has been set, but per-process network counters are currently not supported with an alternate filesystem.", procStats.Hostfs.ResolveHostFS(""))
-		procStats.EnableNetwork = false
-	}
-
 	if procStats.EnableNetwork && len(procStats.NetworkMetrics) == 0 {
 		procStats.logger.Warnf("Collecting all network metrics per-process; this will produce a large volume of data.")
 	}

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -99,17 +99,6 @@ func TestNetworkFetch(t *testing.T) {
 	require.NotEmpty(t, networkData)
 }
 
-func TestNetworkSkipWithHostfs(t *testing.T) {
-	testConfig := Stats{
-		Hostfs:        resolve.NewTestResolver("testpath"),
-		EnableNetwork: true,
-	}
-
-	err := testConfig.Init()
-	require.NoError(t, err)
-	require.False(t, testConfig.EnableNetwork)
-}
-
 func TestNetworkFilter(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("Network data only available on linux")


### PR DESCRIPTION
## What does this PR do?

When I added support for network data in `/proc/PID/net`, I had a bit of a brain glitch and forgot that the data in `proc/PID/net` isn't per-PID, its per network namespace. Therefore the check to forbid it from working in a container is a bit counter-productive, since this will be most useful in a namespaced environment.

## Why is it important?

This makes this metric reporter kind of useless.

## Checklist


- [x] My code follows the style guidelines of this project
- [ ] I have added an entry in `CHANGELOG.md`
