### PR TITLE
metric/system/cgroup/cgv2: ensure Rdev is correct width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix thread safety in process code #43
 - Fix process package build on AIX #54
+- Ensure correct devID width in cgv2 #74
 
 ## [0.4.4]
 

--- a/metric/system/cgroup/cgv2/io_helper_linux.go
+++ b/metric/system/cgroup/cgv2/io_helper_linux.go
@@ -51,7 +51,7 @@ func fetchDeviceName(major uint64, minor uint64) (bool, string, error) {
 		if !ok {
 			return nil
 		}
-		devID = infoT.Rdev
+		devID = uint64(infoT.Rdev)
 
 		// do some bitmapping to extract the major and minor device values
 		// The odd duplicated logic here is to deal with 32 and 64 bit values.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

On mips platforms, Stat_t.Rdev is uint32 (for example https://cs.opensource.google/go/go/+/refs/tags/go1.20.1:src/syscall/ztypes_linux_mips64.go;l=107) resulting in a type error. So explicitly convert to uint64.
```
$ grep 'Rdev\s*uint32' *.go
syscall_linux_mips64x.go:	Rdev       uint32
ztypes_dragonfly_amd64.go:	Rdev     uint32
ztypes_freebsd_386.go:	Rdev          uint32
ztypes_freebsd_amd64.go:	Rdev          uint32
ztypes_freebsd_arm.go:	Rdev          uint32
ztypes_freebsd_arm64.go:	Rdev          uint32
ztypes_linux_mips.go:	Rdev    uint32
ztypes_linux_mips64.go:	Rdev    uint32
ztypes_linux_mips64le.go:	Rdev    uint32
ztypes_linux_mipsle.go:	Rdev    uint32
```

Please inform on need for backport.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The current code will not build on mips platforms.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

