### PR TITLE
Return FQDN in new field

### DIFF
--- a/metric/system/host/host.go
+++ b/metric/system/host/host.go
@@ -26,14 +26,15 @@ import (
 
 // MapHostInfo converts the HostInfo to a MapStr based on ECS.
 func MapHostInfo(useFQDN bool, info types.HostInfo) mapstr.M {
-	hostname := info.Hostname
+	name := info.Hostname
 	if useFQDN {
-		hostname = info.FQDN
+		name = info.FQDN
 	}
 
 	data := mapstr.M{
 		"host": mapstr.M{
-			"hostname":     hostname,
+			"name":         name,
+			"hostname":     info.Hostname,
 			"architecture": info.Architecture,
 			"os": mapstr.M{
 				"platform": info.OS.Platform,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Fixes a small error made in #75.  Instead of having the `host.MapHostInfo` function report the FDQN via the `host.hostname` field, it reports it via a new field, `host.name`.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

As decided in https://github.com/elastic/beats/issues/1070#issuecomment-1323387491, we want `host.name` to report the FQDN (when the FQDN is requested) and `host.hostname` to continue reporting the short hostname as before.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Follow up to #75

