### PR TITLE
Move SetupInfoUserMetrics out of a cgo build constraint

### DIFF
--- a/report/setup.go
+++ b/report/setup.go
@@ -22,10 +22,7 @@ package report
 
 import (
 	"fmt"
-	"os"
-	"os/user"
 	"runtime"
-	"strconv"
 	"time"
 
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -74,24 +71,6 @@ func SetupMetrics(logger *logp.Logger, name, version string) error {
 	setupPlatformSpecificMetrics(logger, processStats)
 
 	return nil
-}
-
-// SetupInfoUserMetrics adds user data to the `info` registry component
-// this is performed async, as on windows user lookup can take up to a minute.
-func SetupInfoUserMetrics() {
-	infoRegistry := monitoring.GetNamespace("info").GetRegistry()
-	go func() {
-		if u, err := user.Current(); err != nil {
-			// This usually happens if the user UID does not exist in /etc/passwd. It might be the case on K8S
-			// if the user set securityContext.runAsUser to an arbitrary value.
-			monitoring.NewString(infoRegistry, "uid").Set(strconv.Itoa(os.Getuid()))
-			monitoring.NewString(infoRegistry, "gid").Set(strconv.Itoa(os.Getgid()))
-		} else {
-			monitoring.NewString(infoRegistry, "username").Set(u.Username)
-			monitoring.NewString(infoRegistry, "uid").Set(u.Uid)
-			monitoring.NewString(infoRegistry, "gid").Set(u.Gid)
-		}
-	}()
 }
 
 // processName truncates the name if it is longer than 15 characters, so we don't fail process checks later on


### PR DESCRIPTION
## What does this PR do?

When I did https://github.com/elastic/elastic-agent-system-metrics/pull/80, I didn't notice that I put the code in a file with a cgo build constraint, and proceeded to not notice until I ran `mage package` on something else. None of this code actually requires cgo, so place it in `metrics_common.go`

## Why is it important?

This code doesn't require cgo.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`
