### PR TITLE
reduce resource usage

### DIFF
--- a/metric/system/cgroup/reader.go
+++ b/metric/system/cgroup/reader.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-system-metrics/metric/system/cgroup/cgv1"
@@ -78,6 +79,12 @@ type mount struct {
 	fullPath   string // Absolute path to the cgroup. It's the mountpoint joined with the path.
 }
 
+// pathListWithTime combines PathList with a timestamp.
+type pathListWithTime struct {
+	added    time.Time
+	pathList PathList
+}
+
 // Reader reads cgroup metrics and limits.
 type Reader struct {
 	// Mountpoint of the root filesystem. Defaults to / if not set. This can be
@@ -87,7 +94,7 @@ type Reader struct {
 	cgroupsHierarchyOverride string
 	cgroupMountpoints        Mountpoints // Mountpoints for each subsystem (e.g. cpu, cpuacct, memory, blkio).
 
-	// Cache to map known v2 cgroup controllerPaths to PathList.
+	// Cache to map known v2 cgroup controllerPaths to pathListWithTime.
 	v2ControllerPathCache sync.Map
 }
 

--- a/metric/system/cgroup/reader.go
+++ b/metric/system/cgroup/reader.go
@@ -85,6 +85,11 @@ type pathListWithTime struct {
 	pathList PathList
 }
 
+type pathCache struct {
+	sync.RWMutex
+	cache map[string]pathListWithTime
+}
+
 // Reader reads cgroup metrics and limits.
 type Reader struct {
 	// Mountpoint of the root filesystem. Defaults to / if not set. This can be
@@ -95,7 +100,7 @@ type Reader struct {
 	cgroupMountpoints        Mountpoints // Mountpoints for each subsystem (e.g. cpu, cpuacct, memory, blkio).
 
 	// Cache to map known v2 cgroup controllerPaths to pathListWithTime.
-	v2ControllerPathCache sync.Map
+	v2ControllerPathCache pathCache
 }
 
 // ReaderOptions holds options for NewReaderOptions.
@@ -146,6 +151,7 @@ func NewReaderOptions(opts ReaderOptions) (*Reader, error) {
 		ignoreRootCgroups:        opts.IgnoreRootCgroups,
 		cgroupsHierarchyOverride: opts.CgroupsHierarchyOverride,
 		cgroupMountpoints:        mountpoints,
+		v2ControllerPathCache:    pathCache{cache: make(map[string]pathListWithTime)},
 	}, nil
 }
 

--- a/metric/system/cgroup/reader.go
+++ b/metric/system/cgroup/reader.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-system-metrics/metric/system/cgroup/cgv1"
@@ -68,7 +69,7 @@ const (
 	memoryStat  = "memory"
 )
 
-//nolint: deadcode,structcheck,unused // needed by other platforms
+// nolint: deadcode,structcheck,unused // needed by other platforms
 type mount struct {
 	subsystem  string // Subsystem name (e.g. cpuacct).
 	mountpoint string // Mountpoint of the subsystem (e.g. /cgroup/cpuacct).
@@ -85,6 +86,9 @@ type Reader struct {
 	ignoreRootCgroups        bool // Ignore a cgroup when its path is "/".
 	cgroupsHierarchyOverride string
 	cgroupMountpoints        Mountpoints // Mountpoints for each subsystem (e.g. cpu, cpuacct, memory, blkio).
+
+	// Cache to map known v2 cgroup controllerPaths to PathList.
+	v2ControllerPathCache sync.Map
 }
 
 // ReaderOptions holds options for NewReaderOptions.

--- a/metric/system/cgroup/util.go
+++ b/metric/system/cgroup/util.go
@@ -67,7 +67,7 @@ type PathList struct {
 
 // Flatten combines the V1 and V2 cgroups in cases where we don't need a map with keys
 func (pl PathList) Flatten() []ControllerPath {
-	list := []ControllerPath{}
+	list := make([]ControllerPath, 0, len(pl.V1)+len(pl.V2))
 	for _, v1 := range pl.V1 {
 		list = append(list, v1)
 	}

--- a/metric/system/process/process_darwin.go
+++ b/metric/system/process/process_darwin.go
@@ -64,8 +64,8 @@ func (procStats *Stats) FetchPids() (ProcsMap, []ProcState, error) {
 
 	bbuf := bytes.NewBuffer(buf)
 
-	procMap := make(ProcsMap, 0)
-	var plist []ProcState
+	procMap := make(ProcsMap, len(names))
+	plist := make([]ProcState, 0, len(names))
 
 	for i := 0; i < num; i++ {
 		if err := binary.Read(bbuf, binary.LittleEndian, &pid); err != nil {

--- a/metric/system/process/process_linux_common.go
+++ b/metric/system/process/process_linux_common.go
@@ -58,8 +58,8 @@ func (procStats *Stats) FetchPids() (ProcsMap, []ProcState, error) {
 		return nil, nil, fmt.Errorf("error reading directory names: %w", err)
 	}
 
-	procMap := make(ProcsMap)
-	var plist []ProcState
+	procMap := make(ProcsMap, len(names))
+	plist := make([]ProcState, 0, len(names))
 
 	// Iterate over the directory, fetch just enough info so we can filter based on user input.
 	logger := logp.L()

--- a/metric/system/process/process_windows.go
+++ b/metric/system/process/process_windows.go
@@ -38,8 +38,9 @@ func (procStats *Stats) FetchPids() (ProcsMap, []ProcState, error) {
 		return nil, nil, fmt.Errorf("EnumProcesses failed: %w", err)
 	}
 
-	procMap := make(ProcsMap, 0)
-	var plist []ProcState
+	procMap := make(ProcsMap, len(names))
+	plist := make([]ProcState, 0, len(names))
+
 	// This is probably the only implementation that doesn't benefit from our
 	// little fillPid callback system. We'll need to iterate over everything
 	// manually.


### PR DESCRIPTION
## What does this PR do?

Reduce resource usage by preallocating memory and using caches.

## Why is it important?

`elastic/elastic-agent-system-metrics` is a direct dependency of beats like `metricbeat`.

![20231026-095255](https://github.com/elastic/elastic-agent-system-metrics/assets/1132494/98e9b8e4-bd60-4e5f-b858-528cd9744839)

As shown in the above screenshot, `metricbeat` spends most of its time in `elastic/elastic-agent-system-metrics` doing syscalls to walk directories.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.md`~~

