### PR TITLE
Fix metrics collection for privileged process on Windows

### DIFF
--- a/metric/system/process/process_aix.go
+++ b/metric/system/process/process_aix.go
@@ -195,3 +195,7 @@ func FillPidMetrics(_ resolve.Resolver, pid int, state ProcState, filter func(st
 
 	return state, nil
 }
+
+func FillOtherMetricsMoreAccess(_ int, state ProcState) (ProcState, error) {
+	return state, nil
+}

--- a/metric/system/process/process_aix.go
+++ b/metric/system/process/process_aix.go
@@ -196,6 +196,6 @@ func FillPidMetrics(_ resolve.Resolver, pid int, state ProcState, filter func(st
 	return state, nil
 }
 
-func FillOtherMetricsMoreAccess(_ int, state ProcState) (ProcState, error) {
+func FillMetricsRequiringMoreAccess(_ int, state ProcState) (ProcState, error) {
 	return state, nil
 }

--- a/metric/system/process/process_darwin.go
+++ b/metric/system/process/process_darwin.go
@@ -243,3 +243,7 @@ func sysctl(mib []C.int, old *byte, oldlen *uintptr,
 	}
 	return err
 }
+
+func FillOtherMetricsMoreAccess(_ int, state ProcState) (ProcState, error) {
+	return state, nil
+}

--- a/metric/system/process/process_darwin.go
+++ b/metric/system/process/process_darwin.go
@@ -244,6 +244,6 @@ func sysctl(mib []C.int, old *byte, oldlen *uintptr,
 	return err
 }
 
-func FillOtherMetricsMoreAccess(_ int, state ProcState) (ProcState, error) {
+func FillMetricsRequiringMoreAccess(_ int, state ProcState) (ProcState, error) {
 	return state, nil
 }

--- a/metric/system/process/process_linux_common.go
+++ b/metric/system/process/process_linux_common.go
@@ -462,6 +462,6 @@ func getProcState(b byte) PidState {
 	return Unknown
 }
 
-func FillOtherMetricsMoreAccess(_ int, state ProcState) (ProcState, error) {
+func FillMetricsRequiringMoreAccess(_ int, state ProcState) (ProcState, error) {
 	return state, nil
 }

--- a/metric/system/process/process_linux_common.go
+++ b/metric/system/process/process_linux_common.go
@@ -461,3 +461,7 @@ func getProcState(b byte) PidState {
 	}
 	return Unknown
 }
+
+func FillOtherMetricsMoreAccess(_ int, state ProcState) (ProcState, error) {
+	return state, nil
+}

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -612,7 +612,11 @@ func runThreads(t *testing.T) *exec.Cmd {
 	var log string
 	require.Eventually(t,
 		func() bool {
-			log += b.String()
+			if cmd.ProcessState != nil {
+				t.Fatalf("Process exited with error: '%s'", cmd.ProcessState.String())
+			}
+			line := b.String()
+			log += line
 			return strings.Contains(log, "running")
 		},
 		time.Second, 50*time.Millisecond,

--- a/metric/system/process/process_windows.go
+++ b/metric/system/process/process_windows.go
@@ -143,12 +143,12 @@ func FillPidMetrics(_ resolve.Resolver, pid int, state ProcState, _ func(string)
 func FillMetricsRequiringMoreAccess(pid int, state ProcState) (ProcState, error) {
 	argList, err := getProcArgs(pid)
 	if err != nil {
-		return state, fmt.Errorf("error fetching process args: %w", NotEnoughPrivilegesErr{Err: err})
+		return state, fmt.Errorf("error fetching process args: %w", NonFatalErr{Err: err})
 	}
 	state.Args = argList
 
 	if numThreads, err := FetchNumThreads(pid); err != nil {
-		return state, fmt.Errorf("error fetching num threads: %w", NotEnoughPrivilegesErr{Err: err})
+		return state, fmt.Errorf("error fetching num threads: %w", NonFatalErr{Err: err})
 	} else {
 		state.NumThreads = opt.IntWith(numThreads)
 	}

--- a/metric/system/process/process_windows.go
+++ b/metric/system/process/process_windows.go
@@ -143,12 +143,12 @@ func FillPidMetrics(_ resolve.Resolver, pid int, state ProcState, _ func(string)
 func FillOtherMetricsMoreAccess(pid int, state ProcState) (ProcState, error) {
 	argList, err := getProcArgs(pid)
 	if err != nil {
-		return state, fmt.Errorf("error fetching process args: %w", err)
+		return state, fmt.Errorf("error fetching process args: %w", NotEnoughPrivilegiesErr{Err: err})
 	}
 	state.Args = argList
 
 	if numThreads, err := FetchNumThreads(pid); err != nil {
-		return state, fmt.Errorf("error fetching num threads: %w", err)
+		return state, fmt.Errorf("error fetching num threads: %w", NotEnoughPrivilegiesErr{Err: err})
 	} else {
 		state.NumThreads = opt.IntWith(numThreads)
 	}

--- a/metric/system/process/process_windows_test.go
+++ b/metric/system/process/process_windows_test.go
@@ -42,19 +42,24 @@ func TestGetInfoForPid_numThreads(t *testing.T) {
 	expected := 45
 
 	cmd := runThreads(t)
-	got, err := GetInfoForPid(
+	state, err := GetInfoForPid(
 		resolve.NewTestResolver("/"), cmd.Process.Pid)
 	require.NoError(t, err, "failed to GetInfoForPid")
 
-	if !got.NumThreads.Exists() {
-		bs, err := json.Marshal(got)
+	state, err = FillOtherMetricsMoreAccess(cmd.Process.Pid, state)
+	if err != nil {
+		t.Fatalf("error calling FillOtherMetricsMoreAccess: %s", err)
+	}
+
+	if !state.NumThreads.Exists() {
+		bs, err := json.Marshal(state)
 		if err != nil {
 			t.Logf("could not marshal ProcState: %v", err)
 		}
 		t.Fatalf("num_thread was not collected. Collected info: %s", bs)
 	}
 
-	numThreads := got.NumThreads.ValueOr(-1)
+	numThreads := state.NumThreads.ValueOr(-1)
 	if expected != numThreads {
 		// it might be an older Windows version or, by the time we got the num_threads,
 		// the program was indeed using only what it spawned

--- a/metric/system/process/process_windows_test.go
+++ b/metric/system/process/process_windows_test.go
@@ -46,9 +46,9 @@ func TestGetInfoForPid_numThreads(t *testing.T) {
 		resolve.NewTestResolver("/"), cmd.Process.Pid)
 	require.NoError(t, err, "failed to GetInfoForPid")
 
-	state, err = FillOtherMetricsMoreAccess(cmd.Process.Pid, state)
+	state, err = FillMetricsRequiringMoreAccess(cmd.Process.Pid, state)
 	if err != nil {
-		t.Fatalf("error calling FillOtherMetricsMoreAccess: %s", err)
+		t.Fatalf("error calling FillMetricsRequiringMoreAccess: %s", err)
 	}
 
 	if !state.NumThreads.Exists() {


### PR DESCRIPTION
## What does this PR do?

It improves metric collection on Windows hosts so we can collect some metrics from privileged process like Elastic Endpoint or Elastic-Agent. In order to achieve that metrics collection for Windows are grouped by the access level required to collect metrics. First the metrics that can be collected with `PROCESS_QUERY_LIMITED_INFORMATION` are collected, then the others are collected. In case the second batch fails, we still report the partial metrics.

## Why is it important?

It allows us to collect CPU and memory metrics from Endpoint and Elastic-Agent, which improves our monitoring dashboards.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.md`

## Author's Checklist
- [x] Make sure nothing broke on:
  - [x] Linux
  - [x] MacOS


## Related issues

- Closes https://github.com/elastic/beats/issues/17314
