### PR TITLE
add PssFreeSnapshot

### DIFF
--- a/metric/system/process/process_windows.go
+++ b/metric/system/process/process_windows.go
@@ -94,6 +94,10 @@ func FetchNumThreads(pid int) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("PssCaptureSnapshot failed: %w", err)
 	}
+	defer func() {
+		cHandle, _ := syscall.GetCurrentProcess()
+		PssFreeSnapshot(cHandle, snapshotHandle)
+	}()
 
 	info := PssThreadInformation{}
 	buffSize := unsafe.Sizeof(info)

--- a/metric/system/process/syscall_windows.go
+++ b/metric/system/process/syscall_windows.go
@@ -21,6 +21,7 @@ package process
 //  - https://learn.microsoft.com/en-us/previous-versions/windows/desktop/proc_snap/overview-of-process-snapshotting
 // PssCaptureSnapshot docs in https://learn.microsoft.com/en-us/windows/win32/api/processsnapshot/nf-processsnapshot-psscapturesnapshot
 // PssQuerySnapshot docs in https://learn.microsoft.com/en-us/windows/win32/api/processsnapshot/nf-processsnapshot-pssquerysnapshot
+// PssFreeSnapshot docs in https://learn.microsoft.com/en-us/windows/win32/api/processsnapshot/nf-processsnapshot-pssfreesnapshot
 
 // Use golang.org/x/sys/windows/mkwinsyscall instead of adriansr/mksyscall
 // below once https://github.com/golang/go/issues/42373 is fixed.
@@ -29,6 +30,7 @@ package process
 
 //sys PssCaptureSnapshot(processHandle syscall.Handle, captureFlags PSSCaptureFlags, threadContextFlags uint32, snapshotHandle *syscall.Handle) (err error) [failretval!=0] = kernel32.PssCaptureSnapshot
 //sys PssQuerySnapshot(snapshotHandle syscall.Handle, informationClass uint32, buffer *PssThreadInformation, bufferLength uint32) (err error) [failretval!=0] = kernel32.PssQuerySnapshot
+//sys PssFreeSnapshot(processHandle syscall.Handle, snapshotHandle syscall.Handle) (err error) [failretval!=0] = kernel32.PssFreeSnapshot
 
 // The following constants are PssQueryInformationClass as defined on
 // https://learn.microsoft.com/en-us/windows/win32/api/processsnapshot/ne-processsnapshot-pss_query_information_class

--- a/metric/system/process/zsyscall_windows.go
+++ b/metric/system/process/zsyscall_windows.go
@@ -59,6 +59,7 @@ var (
 
 	procPssCaptureSnapshot = modkernel32.NewProc("PssCaptureSnapshot")
 	procPssQuerySnapshot   = modkernel32.NewProc("PssQuerySnapshot")
+	procPssFreeSnapshot    = modkernel32.NewProc("PssFreeSnapshot")
 )
 
 func PssCaptureSnapshot(processHandle syscall.Handle, captureFlags PSSCaptureFlags, threadContextFlags uint32, snapshotHandle *syscall.Handle) (err error) {
@@ -71,6 +72,14 @@ func PssCaptureSnapshot(processHandle syscall.Handle, captureFlags PSSCaptureFla
 
 func PssQuerySnapshot(snapshotHandle syscall.Handle, informationClass uint32, buffer *PssThreadInformation, bufferLength uint32) (err error) {
 	r1, _, e1 := syscall.Syscall6(procPssQuerySnapshot.Addr(), 4, uintptr(snapshotHandle), uintptr(informationClass), uintptr(unsafe.Pointer(buffer)), uintptr(bufferLength), 0, 0)
+	if r1 != 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func PssFreeSnapshot(processHandle syscall.Handle, snapshotHandle syscall.Handle) (err error) {
+	r1, _, e1 := syscall.Syscall6(procPssFreeSnapshot.Addr(), 2, uintptr(processHandle), uintptr(snapshotHandle), 0, 0, 0, 0)
 	if r1 != 0 {
 		err = errnoErr(e1)
 	}


### PR DESCRIPTION
## What does this PR do?

Frees the memory that is allocated when PssCaptureSnapshot is called.

## Why is it important?

memory leak

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Written by hand.  Need to figure out what needs to happen for "go generate" to work.  Does not work from Mac.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Testing

- run metricbeat 8.11.0 or 8.11.1 on Windows, notice memory consumption of metricbeat continually climbs
- rebuild metricbeat using this path
- memory consumption rises in first 10min or so, but is steady after that

