### PR TITLE
metric/system: preallocate arrays

### DIFF
--- a/metric/system/diskio/diskstat_windows_helper.go
+++ b/metric/system/diskio/diskstat_windows_helper.go
@@ -59,7 +59,7 @@ func ioCounters(names ...string) (map[string]disk.IOCountersStat, error) {
 	if err != nil || len(logicalDisks) == 0 {
 		return nil, err
 	}
-	ret := make(map[string]disk.IOCountersStat)
+	ret := make(map[string]disk.IOCountersStat, len(logicalDisks))
 	for _, drive := range logicalDisks {
 		// not get _Total or Harddrive
 		if len(drive.Name) > 3 {
@@ -158,7 +158,7 @@ func getLogicalDriveStrings() ([]logicalDrive, error) {
 		}
 		return nil, err
 	}
-	var logicalDrives []logicalDrive
+	logicalDrives := make([]logicalDrive, 0, len(lpBuffer))
 	for _, v := range lpBuffer {
 		if v >= 65 && v <= 90 {
 			s := string(v)

--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -115,8 +115,8 @@ func (procStats *Stats) Get() ([]mapstr.M, []mapstr.M, error) {
 	}
 
 	// Format the list to the MapStr type used by the outputs
-	var procs []mapstr.M
-	var rootEvents []mapstr.M
+	procs := make([]mapstr.M, 0, len(plist))
+	rootEvents := make([]mapstr.M, 0, len(plist))
 
 	for _, process := range plist {
 		process := process

--- a/metric/system/process/process_darwin.go
+++ b/metric/system/process/process_darwin.go
@@ -64,8 +64,8 @@ func (procStats *Stats) FetchPids() (ProcsMap, []ProcState, error) {
 
 	bbuf := bytes.NewBuffer(buf)
 
-	procMap := make(ProcsMap, 0)
-	var plist []ProcState
+	procMap := make(ProcsMap, num)
+	plist := make([]ProcState, 0, num)
 
 	for i := 0; i < num; i++ {
 		if err := binary.Read(bbuf, binary.LittleEndian, &pid); err != nil {
@@ -193,7 +193,7 @@ func getProcArgs(pid int, filter func(string) bool) ([]string, string, mapstr.M,
 	}
 
 	// read CLI args
-	var argv []string
+	argv := make([]string, 0, argc)
 	for i := 0; i < int(argc); i++ {
 		arg, err := bbuf.ReadBytes(0)
 		if err == io.EOF {

--- a/metric/system/process/process_linux_common.go
+++ b/metric/system/process/process_linux_common.go
@@ -58,8 +58,8 @@ func (procStats *Stats) FetchPids() (ProcsMap, []ProcState, error) {
 		return nil, nil, fmt.Errorf("error reading directory names: %w", err)
 	}
 
-	procMap := make(ProcsMap)
-	var plist []ProcState
+	procMap := make(ProcsMap, len(names))
+	plist := make([]ProcState, 0, len(names))
 
 	// Iterate over the directory, fetch just enough info so we can filter based on user input.
 	logger := logp.L()

--- a/metric/system/process/process_windows.go
+++ b/metric/system/process/process_windows.go
@@ -38,8 +38,8 @@ func (procStats *Stats) FetchPids() (ProcsMap, []ProcState, error) {
 		return nil, nil, fmt.Errorf("EnumProcesses failed: %w", err)
 	}
 
-	procMap := make(ProcsMap, 0)
-	var plist []ProcState
+	procMap := make(ProcsMap, len(pids))
+	plist := make([]ProcState, 0, len(pids))
 	// This is probably the only implementation that doesn't benefit from our
 	// little fillPid callback system. We'll need to iterate over everything
 	// manually.


### PR DESCRIPTION
## What does this PR do?

Whenever possible, preallocate array to the correct size instead of letting arrays "grow". This reduces the load on the Garbage Collector and improves memory usage efficiency.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.md`~~

