### PR TITLE
CI: remove deprecated skip-go-install option

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -48,9 +48,6 @@ jobs:
           # into fixing all linting issues in the whole file instead
           args: --timeout=30m --whole-files
 
-          # Optional: if set to true then the action will use pre-installed Go.
-          skip-go-installation: true
-
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true
 
@@ -85,9 +82,6 @@ jobs:
           # fix a single line in an existing codebase and the linter would force them
           # into fixing all linting issues in the whole file instead
           args: --timeout=30m --whole-files
-
-          # Optional: if set to true then the action will use pre-installed Go.
-          skip-go-installation: true
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,9 +32,7 @@ linters:
     - unused # checks Go code for unused constants, variables, functions and types
     - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
     - ineffassign # detects when assignments to existing variables are not used
-    - structcheck # finds unused struct fields
     - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
-    - varcheck # Finds unused global variables and constants
     - asciicheck # simple linter to check that your code does not contain non-ASCII identifiers
     - bodyclose # checks whether HTTP response body is closed successfully
     - durationcheck # check for two durations multiplied together


### PR DESCRIPTION

## What does this PR do?

`skip-go-install` was removed with
https://github.com/golangci/golangci-lint-action/commit/423fbafafc226b312a399e5a5c942041f5d6f24f. As this optional argument is still used in golangci-lint-action, the action fails with:
```
Unexpected input(s) 'skip-go-installation', valid inputs are ['version', 'args', 'working-directory', 'github-token', 'only-new-issues', 'skip-cache', 'skip-pkg-cache', 'skip-build-cache', 'install-mode']
```
https://github.com/elastic/elastic-agent-system-metrics/actions/runs/7017910507/job/19092190110#step:6:1

