### PR TITLE
Add metrics for disk reads and writes per cgroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Add metrics from `/proc/[pid]/io`
+- Add metrics for disk reads and writes per cgroup
 
 ### Changed
 

--- a/metric/system/cgroup/cgv1/blkio.go
+++ b/metric/system/cgroup/cgv1/blkio.go
@@ -35,10 +35,12 @@ import (
 //
 // https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt
 type BlockIOSubsystem struct {
-	ID    string   `json:"id,omitempty"`                   // ID of the cgroup.
-	Path  string   `json:"path,omitempty"`                 // Path to the cgroup relative to the cgroup subsystem's mountpoint.
-	Total TotalIOs `json:"total,omitempty" struct:"total"` // Throttle limits for upper IO rates and metrics.
-	//CFQ      CFQScheduler   `json:"cfq,omitempty"`      // Completely fair queue scheduler limits and metrics.
+	ID     string   `json:"id,omitempty"`                     // ID of the cgroup.
+	Path   string   `json:"path,omitempty"`                   // Path to the cgroup relative to the cgroup subsystem's mountpoint.
+	Total  TotalIOs `json:"total,omitempty" struct:"total"`   // Throttle limits for upper IO rates and metrics.
+	Reads  TotalIOs `json:"reads,omitempty" struct:"reads"`   // Throttle limits for upper IO rates and metrics.
+	Writes TotalIOs `json:"writes,omitempty" struct:"writes"` // Throttle limits for upper IO rates and metrics.
+	//CFQ      CFQScheduler   `json:"cfq,omitempty"`          // Completely fair queue scheduler limits and metrics.
 }
 
 // TotalIOs wraps the totals for blkio
@@ -196,6 +198,10 @@ func blkioThrottle(path string, blkio *BlockIOSubsystem) error {
 	for _, dev := range devices {
 		blkio.Total.Bytes += dev.Bytes.Read + dev.Bytes.Write
 		blkio.Total.Ios += dev.IOs.Read + dev.IOs.Write
+		blkio.Reads.Bytes += dev.Bytes.Read
+		blkio.Reads.Ios += dev.IOs.Read
+		blkio.Writes.Bytes += dev.Bytes.Write
+		blkio.Writes.Ios += dev.IOs.Write
 	}
 	return nil
 }

--- a/metric/system/cgroup/cgv1/blkio_test.go
+++ b/metric/system/cgroup/cgv1/blkio_test.go
@@ -58,8 +58,12 @@ func TestBlkioThrottle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, uint64(46), blkio.Total.Ios)
-	assert.Equal(t, uint64(1648128), blkio.Total.Bytes)
+	assert.Equal(t, uint64(48), blkio.Total.Ios)
+	assert.Equal(t, uint64(1651200), blkio.Total.Bytes)
+	assert.Equal(t, uint64(46), blkio.Reads.Ios)
+	assert.Equal(t, uint64(1648128), blkio.Reads.Bytes)
+	assert.Equal(t, uint64(2), blkio.Writes.Ios)
+	assert.Equal(t, uint64(3072), blkio.Writes.Bytes)
 
 }
 

--- a/metric/system/cgroup/testdata/docker/sys/fs/cgroup/blkio/docker/b29faf21b7eff959f64b4192c34d5d67a707fe8561e9eaa608cb27693fba4242/blkio.throttle.io_service_bytes
+++ b/metric/system/cgroup/testdata/docker/sys/fs/cgroup/blkio/docker/b29faf21b7eff959f64b4192c34d5d67a707fe8561e9eaa608cb27693fba4242/blkio.throttle.io_service_bytes
@@ -1,16 +1,16 @@
 7:0 Read 4608
-7:0 Write 0
+7:0 Write 1024
 7:0 Sync 0
-7:0 Async 4608
-7:0 Total 4608
+7:0 Async 5632
+7:0 Total 5632
 253:0 Read 4608
-253:0 Write 0
+253:0 Write 2048
 253:0 Sync 0
-253:0 Async 4608
-253:0 Total 4608
+253:0 Async 6656
+253:0 Total 6656
 253:1 Read 1638912
 253:1 Write 0
 253:1 Sync 0
 253:1 Async 1638912
 253:1 Total 1638912
-Total 1648128
+Total 1651200

--- a/metric/system/cgroup/testdata/docker/sys/fs/cgroup/blkio/docker/b29faf21b7eff959f64b4192c34d5d67a707fe8561e9eaa608cb27693fba4242/blkio.throttle.io_serviced
+++ b/metric/system/cgroup/testdata/docker/sys/fs/cgroup/blkio/docker/b29faf21b7eff959f64b4192c34d5d67a707fe8561e9eaa608cb27693fba4242/blkio.throttle.io_serviced
@@ -1,16 +1,16 @@
 7:0 Read 2
-7:0 Write 0
+7:0 Write 1
 7:0 Sync 0
-7:0 Async 2
-7:0 Total 2
+7:0 Async 3
+7:0 Total 3
 253:0 Read 2
-253:0 Write 0
+253:0 Write 1
 253:0 Sync 0
 253:0 Async 2
 253:0 Total 2
 253:1 Read 42
 253:1 Write 0
 253:1 Sync 0
-253:1 Async 42
-253:1 Total 42
-Total 46
+253:1 Async 43
+253:1 Total 43
+Total 48


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR adds reads and writes metrics for cgroups V1. Currently, only the total of reads and writes is available and this metric alone is not really useful to understand what is happening inside a container.

## Why is it important?

These metrics are important to understand what is happening inside a container running on Kubernetes or Docker and to attribute reads and writes on a host to running containers.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

