### PR TITLE
Fix process filter test

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -101,7 +101,7 @@ linters-settings:
 
   nolintlint:
     # Enable to ensure that nolint directives are all used. Default is true.
-    allow-unused: false
+    allow-unused: true
     # Disable to ensure that nolint directives don't have a leading space. Default is true.
     allow-leading-space: false
     # Exclude following linters from requiring an explanation.  Default is [].

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -657,8 +657,7 @@ func initTestResolver() (Stats, error) {
 	return testConfig, err
 }
 
-// nolint: deadcode,structcheck,unused // needed by other platforms
-func sliceContains(s []string, e string) bool {
+func sliceContains(s []string, e string) bool { //nolint: deadcode,structcheck,unused // needed by other platforms
 	for _, v := range s {
 		if e == v {
 			return true

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -360,6 +360,9 @@ func TestProcCpuPercentage(t *testing.T) {
 }
 
 func TestIncludeTopProcesses(t *testing.T) {
+	// noop line so `runThreads` is not marked as unsued for CI on linux
+	// can't use linter directives, since they'll fail on platforms where `runthreads` IS used
+	// so just do this.
 	_ = runThreads
 	processes := []ProcState{
 		{

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -173,7 +173,7 @@ func TestNetworkFilter(t *testing.T) {
 
 	_, exists := data.GetValue("network.ip.Forwarding")
 	require.NoError(t, exists, "filter did not preserve key")
-	ipMetrics, exists := data.GetValue("network.ip")
+	ipMetrics, _ := data.GetValue("network.ip")
 	require.Equal(t, 1, len(ipMetrics.(map[string]interface{})))
 }
 
@@ -196,7 +196,10 @@ func TestFilter(t *testing.T) {
 
 	procData, _, err := testConfig.Get()
 	assert.NoError(t, err, "GetOne")
-	assert.Equal(t, 2, len(procData))
+	// the total count of processes can either be one or two,
+	// depending on if the highest-mem-usage process and
+	// highest-cpu-usage process are the same.
+	assert.GreaterOrEqual(t, 1, len(procData))
 
 	testZero := Stats{
 		Procs:  []string{".*"},

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -584,7 +584,7 @@ func TestIncludeTopProcesses(t *testing.T) {
 //go:generate docker run --rm -v ./testdata:/app --entrypoint g++ docker.elastic.co/beats-dev/golang-crossbuild:1.21.0-main -pthread -std=c++11 -o /app/threads /app/threads.cpp
 //go:generate docker run --rm -v ./testdata:/app --entrypoint o64-clang++ docker.elastic.co/beats-dev/golang-crossbuild:1.21.0-darwin -pthread -std=c++11 -o /app/threads-darwin /app/threads.cpp
 //go:generate docker run --rm -v ./testdata:/app --entrypoint x86_64-w64-mingw32-g++-posix docker.elastic.co/beats-dev/golang-crossbuild:1.21.0-main -pthread -std=c++11 -o /app/threads.exe /app/threads.cpp
-func runThreads(t *testing.T) *exec.Cmd {
+func runThreads(t *testing.T) *exec.Cmd { //nolint: deadcode,structcheck,unused // needed by other platforms
 	t.Helper()
 
 	supportedPlatforms := []string{"linux/amd64", "darwin/amd64", "windows/amd64"}
@@ -657,6 +657,7 @@ func initTestResolver() (Stats, error) {
 	return testConfig, err
 }
 
+// nolint: deadcode,structcheck,unused // needed by other platforms
 func sliceContains(s []string, e string) bool {
 	for _, v := range s {
 		if e == v {

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -360,6 +360,7 @@ func TestProcCpuPercentage(t *testing.T) {
 }
 
 func TestIncludeTopProcesses(t *testing.T) {
+	_ = runThreads
 	processes := []ProcState{
 		{
 			Pid: opt.IntWith(1),
@@ -584,7 +585,7 @@ func TestIncludeTopProcesses(t *testing.T) {
 //go:generate docker run --rm -v ./testdata:/app --entrypoint g++ docker.elastic.co/beats-dev/golang-crossbuild:1.21.0-main -pthread -std=c++11 -o /app/threads /app/threads.cpp
 //go:generate docker run --rm -v ./testdata:/app --entrypoint o64-clang++ docker.elastic.co/beats-dev/golang-crossbuild:1.21.0-darwin -pthread -std=c++11 -o /app/threads-darwin /app/threads.cpp
 //go:generate docker run --rm -v ./testdata:/app --entrypoint x86_64-w64-mingw32-g++-posix docker.elastic.co/beats-dev/golang-crossbuild:1.21.0-main -pthread -std=c++11 -o /app/threads.exe /app/threads.cpp
-func runThreads(t *testing.T) *exec.Cmd { //nolint: deadcode,structcheck,unused // needed by other platforms
+func runThreads(t *testing.T) *exec.Cmd {
 	t.Helper()
 
 	supportedPlatforms := []string{"linux/amd64", "darwin/amd64", "windows/amd64"}
@@ -657,7 +658,7 @@ func initTestResolver() (Stats, error) {
 	return testConfig, err
 }
 
-func sliceContains(s []string, e string) bool { //nolint: deadcode,structcheck,unused // needed by other platforms
+func sliceContains(s []string, e string) bool {
 	for _, v := range s {
 		if e == v {
 			return true

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -360,9 +360,6 @@ func TestProcCpuPercentage(t *testing.T) {
 }
 
 func TestIncludeTopProcesses(t *testing.T) {
-	// noop line so `runThreads` is not marked as unsued for CI on linux
-	// can't use linter directives, since they'll fail on platforms where `runthreads` IS used
-	// so just do this.
 	_ = runThreads
 	processes := []ProcState{
 		{
@@ -588,7 +585,7 @@ func TestIncludeTopProcesses(t *testing.T) {
 //go:generate docker run --rm -v ./testdata:/app --entrypoint g++ docker.elastic.co/beats-dev/golang-crossbuild:1.21.0-main -pthread -std=c++11 -o /app/threads /app/threads.cpp
 //go:generate docker run --rm -v ./testdata:/app --entrypoint o64-clang++ docker.elastic.co/beats-dev/golang-crossbuild:1.21.0-darwin -pthread -std=c++11 -o /app/threads-darwin /app/threads.cpp
 //go:generate docker run --rm -v ./testdata:/app --entrypoint x86_64-w64-mingw32-g++-posix docker.elastic.co/beats-dev/golang-crossbuild:1.21.0-main -pthread -std=c++11 -o /app/threads.exe /app/threads.cpp
-func runThreads(t *testing.T) *exec.Cmd {
+func runThreads(t *testing.T) *exec.Cmd { //nolint: deadcode,structcheck,unused // needed by other platforms
 	t.Helper()
 
 	supportedPlatforms := []string{"linux/amd64", "darwin/amd64", "windows/amd64"}
@@ -661,7 +658,7 @@ func initTestResolver() (Stats, error) {
 	return testConfig, err
 }
 
-func sliceContains(s []string, e string) bool {
+func sliceContains(s []string, e string) bool { //nolint: deadcode,structcheck,unused // needed by other platforms
 	for _, v := range s {
 		if e == v {
 			return true

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -360,7 +360,6 @@ func TestProcCpuPercentage(t *testing.T) {
 }
 
 func TestIncludeTopProcesses(t *testing.T) {
-	_ = runThreads
 	processes := []ProcState{
 		{
 			Pid: opt.IntWith(1),

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -199,7 +199,7 @@ func TestFilter(t *testing.T) {
 	// the total count of processes can either be one or two,
 	// depending on if the highest-mem-usage process and
 	// highest-cpu-usage process are the same.
-	assert.GreaterOrEqual(t, 1, len(procData))
+	assert.GreaterOrEqual(t, len(procData), 1)
 
 	testZero := Stats{
 		Procs:  []string{".*"},


### PR DESCRIPTION
## What does this PR do?

Fixes an issue that came to light with https://github.com/elastic/elastic-agent-system-metrics/pull/125

In certain instances, `FilterTest` will fail, if the process with the most memory usage and most CPU usage are the same.
