### PR TITLE
Make /proc/pid/io lookup failures skippable

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,6 +7,15 @@ env:
   WINDOWS_AGENT_IMAGE: "family/ci-windows-2022"
 
 steps:
+    - plugins:
+      - docker#v5.10.0:
+          image: "${LINUX_AGENT_IMAGE}"
+          always-pull: true
+          command: [".buildkite/scripts/run-linux-tests.sh"]
+          volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock"
+            -"/proc/:/hostfs"
+
   - label: ":golangci-lint: Lint"
     key: lint-test
     command: ".buildkite/scripts/lint_test.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,7 @@ steps:
           command: [".buildkite/scripts/run-linux-tests.sh"]
           volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
-            - "/proc:/root/hostfs/"
+            - "/proc/:/root/hostfs/:type=bind"
 
   - label: ":golangci-lint: Lint"
     key: lint-test

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,7 +14,7 @@ steps:
           command: [".buildkite/scripts/run-linux-tests.sh"]
           volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
-            -"/proc/:/hostfs"
+            - "/proc/:/hostfs"
 
   - label: ":golangci-lint: Lint"
     key: lint-test

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,8 @@ env:
   WINDOWS_AGENT_IMAGE: "family/ci-windows-2022"
 
 steps:
-    - plugins:
+  - label: ":linux: Test unowned processes"
+    plugins:
       - docker#v5.10.0:
           image: "${LINUX_AGENT_IMAGE}"
           always-pull: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,16 +7,6 @@ env:
   WINDOWS_AGENT_IMAGE: "family/ci-windows-2022"
 
 steps:
-  - label: ":linux: Test unowned processes"
-    plugins:
-      - docker#v5.10.0:
-          image: "${LINUX_AGENT_IMAGE}"
-          always-pull: true
-          command: [".buildkite/scripts/run-linux-tests.sh"]
-          volumes:
-            - "/var/run/docker.sock:/var/run/docker.sock"
-            - "/proc/:/root/hostfs/:type=bind"
-
   - label: ":golangci-lint: Lint"
     key: lint-test
     command: ".buildkite/scripts/lint_test.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,7 @@ steps:
           command: [".buildkite/scripts/run-linux-tests.sh"]
           volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
-            - "/proc/:/hostfs"
+            - "/proc:/root/hostfs/"
 
   - label: ":golangci-lint: Lint"
     key: lint-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
  - Fix CmdLine generation and caching for system.process
  - Fix process metrics collection when both cgroup V1 and V2 controllers exist
+ - Skip permissions errors when reading /proc/pid/io
 
 ## [0.7.0]
 

--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -237,7 +237,10 @@ func (procStats *Stats) pidFill(pid int, filter bool) (ProcState, bool, error) {
 	// If we've passed the filter, continue to fill out the rest of the metrics
 	status, err = FillPidMetrics(procStats.Hostfs, pid, status, procStats.isWhitelistedEnvVar)
 	if err != nil {
-		return status, true, fmt.Errorf("FillPidMetrics: %w", err)
+		if !errors.Is(err, NonFatalErr{}) {
+			return status, true, fmt.Errorf("FillPidMetrics: %w", err)
+		}
+		procStats.logger.Debugf("Non-fatal error fetching PID metrics for %d, metrics are valid, but partial: %s", pid, err)
 	}
 
 	if status.CPU.Total.Ticks.Exists() {

--- a/metric/system/process/process_linux_common.go
+++ b/metric/system/process/process_linux_common.go
@@ -124,9 +124,10 @@ func FillPidMetrics(hostfs resolve.Resolver, pid int, state ProcState, filter fu
 		return state, fmt.Errorf("error creating username for pid %d: %w", pid, err)
 	}
 
+	// the /proc/[pid]/io metrics require SYS_PTRACE when run from inside docker
 	state.IO, err = getIOData(hostfs, pid)
 	if err != nil {
-		return state, fmt.Errorf("error fetching IO metrics for pid %d: %w", pid, err)
+		return state, NonFatalErr{Err: fmt.Errorf("/io unavailable; if running inside a container, use SYS_PTRACE: %w", err)}
 	}
 
 	return state, nil

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -86,32 +85,47 @@ func getentGetID(database string, key string) (int, error) {
 	return val, nil
 }
 
+func TestRunningProcessFromOtherUser(t *testing.T) {
+	// cmd := exec.Command("cat", "/etc/passwd")
+	// out, err := cmd.CombinedOutput()
+	// require.NoError(t, err)
+	// t.Logf("Got users: %s", string(out))
+
+	// cmd = exec.Command("cat", "/etc/group")
+	// out, err = cmd.CombinedOutput()
+	// require.NoError(t, err)
+	// t.Logf("Got groups: %s", string(out))
+
+	// cmd = exec.Command("whoami")
+	// out, err = cmd.CombinedOutput()
+	// require.NoError(t, err)
+	// t.Logf("whoami: %s", string(out))
+
+	// cmd = exec.Command("ps", "aux")
+	// out, err = cmd.CombinedOutput()
+	// require.NoError(t, err)
+	// t.Logf("ps: %s", string(out))
+
+	// uid, err := CreateUser("test", 0)
+	// require.NoError(t, err)
+	// t.Logf("uid: %v", uid)
+
+	// cmdHandler := exec.Command("sleep", "60")
+	// cmdHandler.SysProcAttr.Credential = &syscall.Credential{Uid: uint32(uid), Gid: 0}
+
+	cmd := exec.Command("ls", "/hostfs")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err)
+	t.Logf("Got hostfs: %s", string(out))
+
+	cmd = exec.Command("docker", "ps")
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err)
+	t.Logf("Got docker out: %s", string(out))
+
+}
+
 func TestFetchProcessFromOtherUser(t *testing.T) {
-	if runtime.GOOS == "linux" {
-		cmd := exec.Command("cat", "/etc/passwd")
-		out, err := cmd.CombinedOutput()
-		require.NoError(t, err)
-		t.Logf("Got users: %s", string(out))
-
-		cmd = exec.Command("cat", "/etc/group")
-		out, err = cmd.CombinedOutput()
-		require.NoError(t, err)
-		t.Logf("Got groups: %s", string(out))
-
-		cmd = exec.Command("whoami")
-		out, err = cmd.CombinedOutput()
-		require.NoError(t, err)
-		t.Logf("whoami: %s", string(out))
-
-		cmd = exec.Command("ps", "aux")
-		out, err = cmd.CombinedOutput()
-		require.NoError(t, err)
-		t.Logf("ps: %s", string(out))
-
-		uid, err := CreateUser("test", 0)
-		require.NoError(t, err)
-		t.Logf("uid: %v", uid)
-	}
 
 	// If we just used Get() or FetchPids() to get a list of processes on the system, this would produce a bootstrapping problem
 	// where if the code wasn't working (and we were skipping over PIDs not owned by us) this test would pass.

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -103,7 +103,7 @@ func TestFetchProcessFromOtherUser(t *testing.T) {
 		require.NoError(t, err)
 		t.Logf("whoami: %s", string(out))
 
-		uid, err := CreateUser("test", 1000)
+		uid, err := CreateUser("test", 0)
 		require.NoError(t, err)
 		t.Logf("uid: %v", uid)
 	}

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -125,9 +124,17 @@ func TestRunningProcessFromOtherUser(t *testing.T) {
 
 	t.Logf("ps out after create: %s", string(psOut))
 
-	fileOut, err := os.ReadFile(filepath.Join("/proc/", fmt.Sprintf("%d", runPid), "io"))
+	// fileOut, err := os.ReadFile(filepath.Join("/proc/", fmt.Sprintf("%d", runPid), "io"))
+	// require.NoError(t, err)
+	// t.Logf("got out: %s", string(fileOut))
+
+	testStats := Stats{CPUTicks: true, EnableCgroups: true, EnableNetwork: true}
+	err = testStats.Init()
 	require.NoError(t, err)
-	t.Logf("got out: %s", string(fileOut))
+
+	result, err := testStats.GetOne(runPid)
+	require.NoError(t, err)
+	t.Logf("got result: %#v", result)
 }
 
 func TestFetchProcessFromOtherUser(t *testing.T) {

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/opt"
 	"github.com/elastic/elastic-agent-system-metrics/metric/system/cgroup"
 	"github.com/elastic/elastic-agent-system-metrics/metric/system/resolve"
@@ -38,6 +39,7 @@ func TestFetchProcessFromOtherUser(t *testing.T) {
 	// where if the code wasn't working (and we were skipping over PIDs not owned by us) this test would pass.
 	// re-implement part of the core pid-fetch logic
 	// All this does is find a pid that's not owned by us.
+	_ = logp.DevelopmentSetup()
 	dir, err := os.Open("/proc/")
 	require.NoError(t, err, "error opening /proc")
 

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -93,6 +93,11 @@ func TestFetchProcessFromOtherUser(t *testing.T) {
 		require.NoError(t, err)
 		t.Logf("Got users: %s", string(out))
 
+		cmd = exec.Command("groups")
+		out, err = cmd.CombinedOutput()
+		require.NoError(t, err)
+		t.Logf("Got groups: %s", string(out))
+
 		uid, err := CreateUser("test", 1000)
 		require.NoError(t, err)
 		t.Logf("uid: %v", uid)

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -93,10 +93,15 @@ func TestFetchProcessFromOtherUser(t *testing.T) {
 		require.NoError(t, err)
 		t.Logf("Got users: %s", string(out))
 
-		cmd = exec.Command("groups")
+		cmd = exec.Command("cat", "/etc/group")
 		out, err = cmd.CombinedOutput()
 		require.NoError(t, err)
 		t.Logf("Got groups: %s", string(out))
+
+		cmd = exec.Command("whoami")
+		out, err = cmd.CombinedOutput()
+		require.NoError(t, err)
+		t.Logf("whoami: %s", string(out))
 
 		uid, err := CreateUser("test", 1000)
 		require.NoError(t, err)

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -69,6 +69,7 @@ func FindUID(name string) (int, error) {
 	return id, err
 }
 
+// helper to get a passwd entry for a user
 func getentGetID(database string, key string) (int, error) {
 	cmd := exec.Command("getent", database, key)
 	output, err := cmd.Output()
@@ -87,8 +88,9 @@ func getentGetID(database string, key string) (int, error) {
 }
 
 func TestRunningProcessFromOtherUser(t *testing.T) {
-
-	uid, err := CreateUser("test", 0)
+	// test for permission errors by creating a new user, then running a process as that user
+	testUsername := "test"
+	uid, err := CreateUser(testUsername, 0)
 	require.NoError(t, err)
 	t.Logf("uid: %v", uid)
 
@@ -119,6 +121,11 @@ func TestRunningProcessFromOtherUser(t *testing.T) {
 	require.NotEqual(t, uname.Name, result["username"])
 	require.NotZero(t, result["memory"].(map[string]interface{})["size"])
 	t.Logf("got result: %s", result["username"])
+
+	// not sure how ephemeral the Ci environment is, but delete the user anyway
+	cmd := exec.Command("userdel", "-f", testUsername)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "got error deleting user: %s", string(output))
 }
 
 func TestFetchProcessFromOtherUser(t *testing.T) {

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -117,6 +117,7 @@ func TestRunningProcessFromOtherUser(t *testing.T) {
 	// check to make sure we still got valid results
 	require.Equal(t, "sleep 60", result["cmdline"])
 	require.NotEqual(t, uname.Name, result["username"])
+	require.NotZero(t, result["memory"].(map[string]interface{})["size"])
 	t.Logf("got result: %s", result["username"])
 }
 

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -27,6 +27,7 @@ import (
 	"os/user"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -86,43 +87,44 @@ func getentGetID(database string, key string) (int, error) {
 }
 
 func TestRunningProcessFromOtherUser(t *testing.T) {
-	// cmd := exec.Command("cat", "/etc/passwd")
-	// out, err := cmd.CombinedOutput()
-	// require.NoError(t, err)
-	// t.Logf("Got users: %s", string(out))
-
-	// cmd = exec.Command("cat", "/etc/group")
-	// out, err = cmd.CombinedOutput()
-	// require.NoError(t, err)
-	// t.Logf("Got groups: %s", string(out))
-
-	// cmd = exec.Command("whoami")
-	// out, err = cmd.CombinedOutput()
-	// require.NoError(t, err)
-	// t.Logf("whoami: %s", string(out))
-
-	// cmd = exec.Command("ps", "aux")
-	// out, err = cmd.CombinedOutput()
-	// require.NoError(t, err)
-	// t.Logf("ps: %s", string(out))
-
-	// uid, err := CreateUser("test", 0)
-	// require.NoError(t, err)
-	// t.Logf("uid: %v", uid)
-
-	// cmdHandler := exec.Command("sleep", "60")
-	// cmdHandler.SysProcAttr.Credential = &syscall.Credential{Uid: uint32(uid), Gid: 0}
-
-	cmd := exec.Command("ls", "/root")
+	cmd := exec.Command("cat", "/etc/passwd")
 	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "got out: %s", string(out))
-	t.Logf("Got hostfs: %s", string(out))
+	require.NoError(t, err)
+	t.Logf("Got users: %s", string(out))
 
-	cmd = exec.Command("docker", "ps")
+	cmd = exec.Command("cat", "/etc/group")
 	out, err = cmd.CombinedOutput()
-	require.NoError(t, err, "got out: %s", string(out))
-	t.Logf("Got docker out: %s", string(out))
+	require.NoError(t, err)
+	t.Logf("Got groups: %s", string(out))
 
+	cmd = exec.Command("whoami")
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err)
+	t.Logf("whoami: %s", string(out))
+
+	cmd = exec.Command("ps", "aux")
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err)
+	t.Logf("ps: %s", string(out))
+
+	uid, err := CreateUser("test", 0)
+	require.NoError(t, err)
+	t.Logf("uid: %v", uid)
+
+	cmdHandler := exec.Command("sleep", "60")
+	cmdHandler.SysProcAttr.Credential = &syscall.Credential{Uid: uint32(uid), Gid: 0}
+
+	go func() {
+		_, err := cmdHandler.CombinedOutput()
+		require.NoError(t, err)
+
+	}()
+
+	psHandle := exec.Command("ps", "aux")
+	psOut, err := psHandle.CombinedOutput()
+	require.NoError(t, err)
+
+	t.Logf("ps out: %s", string(psOut))
 }
 
 func TestFetchProcessFromOtherUser(t *testing.T) {

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -94,6 +94,13 @@ func TestRunningProcessFromOtherUser(t *testing.T) {
 	require.NoError(t, err)
 	t.Logf("uid: %v", uid)
 
+	t.Cleanup(func() {
+		// not sure how ephemeral the CI environment is, but delete the user anyway
+		cmd := exec.Command("userdel", "-f", testUsername)
+		output, err := cmd.CombinedOutput()
+		require.NoError(t, err, "got error deleting user: %s", string(output))
+	})
+
 	cmdHandler := exec.Command("sleep", "60")
 	cmdHandler.SysProcAttr = &syscall.SysProcAttr{Credential: &syscall.Credential{Uid: uint32(uid), Gid: 0}}
 
@@ -122,10 +129,6 @@ func TestRunningProcessFromOtherUser(t *testing.T) {
 	require.NotZero(t, result["memory"].(map[string]interface{})["size"])
 	t.Logf("got result: %s", result["username"])
 
-	// not sure how ephemeral the Ci environment is, but delete the user anyway
-	cmd := exec.Command("userdel", "-f", testUsername)
-	output, err := cmd.CombinedOutput()
-	require.NoError(t, err, "got error deleting user: %s", string(output))
 }
 
 func TestFetchProcessFromOtherUser(t *testing.T) {

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -112,7 +112,7 @@ func TestRunningProcessFromOtherUser(t *testing.T) {
 	t.Logf("uid: %v", uid)
 
 	cmdHandler := exec.Command("sleep", "60")
-	cmdHandler.SysProcAttr.Credential = &syscall.Credential{Uid: uint32(uid), Gid: 0}
+	cmdHandler.SysProcAttr = &syscall.SysProcAttr{Credential: &syscall.Credential{Uid: uint32(uid), Gid: 0}}
 
 	go func() {
 		_, err := cmdHandler.CombinedOutput()

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -128,7 +128,12 @@ func TestRunningProcessFromOtherUser(t *testing.T) {
 	// require.NoError(t, err)
 	// t.Logf("got out: %s", string(fileOut))
 
-	testStats := Stats{CPUTicks: true, EnableCgroups: true, EnableNetwork: true, Hostfs: resolve.NewTestResolver("/")}
+	testStats := Stats{CPUTicks: true,
+		EnableCgroups: true,
+		EnableNetwork: true,
+		Hostfs:        resolve.NewTestResolver("/"),
+		CgroupOpts:    cgroup.ReaderOptions{RootfsMountpoint: resolve.NewTestResolver("/")},
+	}
 	err = testStats.Init()
 	require.NoError(t, err)
 

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -113,7 +113,7 @@ func TestRunningProcessFromOtherUser(t *testing.T) {
 	// cmdHandler := exec.Command("sleep", "60")
 	// cmdHandler.SysProcAttr.Credential = &syscall.Credential{Uid: uint32(uid), Gid: 0}
 
-	cmd := exec.Command("ls", "/")
+	cmd := exec.Command("ls", "/root")
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "got out: %s", string(out))
 	t.Logf("Got hostfs: %s", string(out))

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -113,7 +113,7 @@ func TestRunningProcessFromOtherUser(t *testing.T) {
 	// cmdHandler := exec.Command("sleep", "60")
 	// cmdHandler.SysProcAttr.Credential = &syscall.Credential{Uid: uint32(uid), Gid: 0}
 
-	cmd := exec.Command("ls", "/hostfs")
+	cmd := exec.Command("ls", "/")
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "got out: %s", string(out))
 	t.Logf("Got hostfs: %s", string(out))

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -128,7 +128,7 @@ func TestRunningProcessFromOtherUser(t *testing.T) {
 	// require.NoError(t, err)
 	// t.Logf("got out: %s", string(fileOut))
 
-	testStats := Stats{CPUTicks: true, EnableCgroups: true, EnableNetwork: true}
+	testStats := Stats{CPUTicks: true, EnableCgroups: true, EnableNetwork: true, Hostfs: resolve.NewTestResolver("/")}
 	err = testStats.Init()
 	require.NoError(t, err)
 

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -103,6 +103,11 @@ func TestFetchProcessFromOtherUser(t *testing.T) {
 		require.NoError(t, err)
 		t.Logf("whoami: %s", string(out))
 
+		cmd = exec.Command("ps", "aux")
+		out, err = cmd.CombinedOutput()
+		require.NoError(t, err)
+		t.Logf("ps: %s", string(out))
+
 		uid, err := CreateUser("test", 0)
 		require.NoError(t, err)
 		t.Logf("uid: %v", uid)

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -115,12 +115,12 @@ func TestRunningProcessFromOtherUser(t *testing.T) {
 
 	cmd := exec.Command("ls", "/hostfs")
 	out, err := cmd.CombinedOutput()
-	require.NoError(t, err)
+	require.NoError(t, err, "got out: %s", string(out))
 	t.Logf("Got hostfs: %s", string(out))
 
 	cmd = exec.Command("docker", "ps")
 	out, err = cmd.CombinedOutput()
-	require.NoError(t, err)
+	require.NoError(t, err, "got out: %s", string(out))
 	t.Logf("Got docker out: %s", string(out))
 
 }


### PR DESCRIPTION
## What does this PR do?

This fixes a change in the behavior of the system metrics where fetching process metrics on a container without `SYS_PTRACE` results in a failure, as `/proc/pid/io` requires `SYS_PTRACE`.

This flies under the radar in a handful of use cases, as our docs mention `SYS_PTRACE` in other contexts, and many users monitoring system data will (in my experience) end up passing `--privileged` due to [a variety of issues with permissions in `proc`](https://stackoverflow.com/questions/56573990/access-to-full-proc-in-docker-container). This issue also doesn't appear outside of docker.

There is a test already that does cover this (although it'll catch it for a permissions error, not a container capability error): `TestFetchProcessFromOtherUser`, however, that test is usually skipped in CI, as the CI environment lacks more than one user. The exact test condition itself can't really be tested without running in a container.

If we want to test this more thoroughly, we'll need some kind of integration test in beats that runs in a container and specifically looks out for skipped processes. These kinds of tests are often flaky, so they tend not to happen. Once we get buildkite set up in the beats repo, we should add a test that specifically looks for skipped metrics, probably by spinning up multiple sub-processes and having beats monitor them directly.

## Why is it important?

This changes the behavior of system metrics inside a container.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`
