### PR TITLE
Fix GetSelf() logic when running with alternate hostfs

### DIFF
--- a/metric/system/process/process_darwin.go
+++ b/metric/system/process/process_darwin.go
@@ -36,6 +36,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"os"
 	"os/user"
 	"strconv"
 	"syscall"
@@ -46,6 +47,12 @@ import (
 	"github.com/elastic/elastic-agent-libs/opt"
 	"github.com/elastic/elastic-agent-system-metrics/metric/system/resolve"
 )
+
+// GetSelfPid is the darwin implementation; see the linux version in
+// process_linux_common.go for more context.
+func GetSelfPid(hostfs resolve.Resolver) (int, error) {
+	return os.Getpid(), nil
+}
 
 // FetchPids returns a map and array of pids
 func (procStats *Stats) FetchPids() (ProcsMap, []ProcState, error) {

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -64,6 +64,16 @@ func TestFetchOtherProcessCgroup(t *testing.T) {
 	t.Logf("Got %d events", len(evts))
 }
 
+func TestGetSelfPidNoHostfs(t *testing.T) {
+	ourPid := os.Getpid()
+
+	foundPid, err := GetSelfPid(resolve.NewTestResolver(""))
+	require.NoError(t, err)
+
+	require.Equal(t, ourPid, foundPid)
+
+}
+
 func TestFetchProcessFromOtherUser(t *testing.T) {
 	_ = logp.DevelopmentSetup()
 	// If we just used Get() or FetchPids() to get a list of processes on the system, this would produce a bootstrapping problem

--- a/metric/system/process/process_windows.go
+++ b/metric/system/process/process_windows.go
@@ -106,7 +106,7 @@ func FetchNumThreads(pid int) (int, error) {
 	// needed, calling CloseHandle has no effect.  Adding here to
 	// remind us to close any handles we open.
 	defer func() {
-		syscall.CloseHandle(currentProcessHandle)
+		_ = syscall.CloseHandle(currentProcessHandle)
 	}()
 
 	var snapshotHandle syscall.Handle

--- a/metric/system/process/process_windows.go
+++ b/metric/system/process/process_windows.go
@@ -94,7 +94,9 @@ func FetchNumThreads(pid int) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("OpenProcess failed for PID %d: %w", pid, err)
 	}
-	defer syscall.CloseHandle(targetProcessHandle)
+	defer func() {
+		_ = syscall.CloseHandle(targetProcessHandle)
+	}()
 
 	currentProcessHandle, err := syscall.GetCurrentProcess()
 	if err != nil {
@@ -103,7 +105,9 @@ func FetchNumThreads(pid int) (int, error) {
 	// The pseudo handle need not be closed when it is no longer
 	// needed, calling CloseHandle has no effect.  Adding here to
 	// remind us to close any handles we open.
-	defer syscall.CloseHandle(currentProcessHandle)
+	defer func() {
+		syscall.CloseHandle(currentProcessHandle)
+	}()
 
 	var snapshotHandle syscall.Handle
 	err = PssCaptureSnapshot(targetProcessHandle, PSSCaptureThreads, 0, &snapshotHandle)

--- a/metric/system/process/process_windows.go
+++ b/metric/system/process/process_windows.go
@@ -20,6 +20,7 @@ package process
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"syscall"
 	"unsafe"
@@ -48,6 +49,12 @@ func (procStats *Stats) FetchPids() (ProcsMap, []ProcState, error) {
 	}
 
 	return procMap, plist, nil
+}
+
+// GetSelfPid is the darwin implementation; see the linux version in
+// process_linux_common.go for more context.
+func GetSelfPid(hostfs resolve.Resolver) (int, error) {
+	return os.Getpid(), nil
 }
 
 // GetInfoForPid returns basic info for the process


### PR DESCRIPTION
Closes https://github.com/elastic/elastic-agent-system-metrics/issues/147

## What does this PR do?

This fixes an issue where `Stats.GetSelf()` would fail when run inside a container while using a hostfs path, as the PID returned by `os.Getpid()` would not be valid outside the container runtime. 

This changes the logic, so if we have a `hostfs` set, `GetSelf` will fetch the pid from `/hostf/proc/self`.

## Why is it important?

This is a bug.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`
