### PR TITLE
Add GetOneRootEvent method to process handler

### DIFF
--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -63,7 +63,7 @@ func ListStates(hostfs resolve.Resolver) ([]ProcState, error) {
 }
 
 // GetPIDState returns the state of a given PID
-// It will return ProcNotExist if the process was not found.
+// It will return ErrProcNotExist if the process was not found.
 func GetPIDState(hostfs resolve.Resolver, pid int) (PidState, error) {
 	// This library still doesn't have a good cross-platform way to distinguish between "does not eixst" and other process errors.
 	// This is a fairly difficult problem to solve in a cross-platform way
@@ -72,7 +72,7 @@ func GetPIDState(hostfs resolve.Resolver, pid int) (PidState, error) {
 		return "", fmt.Errorf("Error trying to find process: %d: %w", pid, err)
 	}
 	if !exists {
-		return "", ProcNotExist
+		return "", ErrProcNotExist
 	}
 	// GetInfoForPid will return the smallest possible dataset for a PID
 	procState, err := GetInfoForPid(hostfs, pid)

--- a/metric/system/process/process_common.go
+++ b/metric/system/process/process_common.go
@@ -35,8 +35,8 @@ import (
 	"github.com/elastic/go-sysinfo"
 )
 
-// ProcNotExist indicates that a process was not found.
-var ProcNotExist = errors.New("process does not exist")
+// ErrProcNotExist indicates that a process was not found.
+var ErrProcNotExist = errors.New("process does not exist")
 
 // ProcsMap is a convenience wrapper for the oft-used idiom of map[int]ProcState
 type ProcsMap map[int]ProcState

--- a/metric/system/process/process_common.go
+++ b/metric/system/process/process_common.go
@@ -25,7 +25,9 @@ import (
 	"sync"
 
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/match"
+	"github.com/elastic/elastic-agent-libs/transform/typeconv"
 	"github.com/elastic/elastic-agent-system-metrics/metric/system/cgroup"
 	"github.com/elastic/elastic-agent-system-metrics/metric/system/resolve"
 	"github.com/elastic/go-sysinfo/types"
@@ -206,4 +208,13 @@ func (procStats *Stats) Init() error {
 		procStats.cgroups = cgReader
 	}
 	return nil
+}
+
+// processRootEvent formats the process state event for the ECS root fields used by the system/process metricsets
+func processRootEvent(process ProcState) mapstr.M {
+	// Create the root event
+	root := process.FormatForRoot()
+	rootMap := mapstr.M{}
+	_ = typeconv.Convert(&rootMap, root)
+	return rootMap
 }

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -126,8 +126,6 @@ func TestGetOneRoot(t *testing.T) {
 	evt, rootEvt, err := testConfig.GetOneRootEvent(os.Getpid())
 	require.NoError(t, err)
 
-	t.Logf("got event: %s\n root: %s", evt.StringToPrint(), rootEvt.StringToPrint())
-
 	require.NotEmpty(t, rootEvt["process"].(map[string]interface{})["pid"])
 
 	require.NotEmpty(t, evt["cpu"])

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -129,9 +129,7 @@ func TestGetOneRoot(t *testing.T) {
 	t.Logf("got event: %s\n root: %s", evt.StringToPrint(), rootEvt.StringToPrint())
 
 	require.NotEmpty(t, rootEvt["process"].(map[string]interface{})["pid"])
-	require.NotEmpty(t, rootEvt["process"].(map[string]interface{})["executable"])
 
-	require.NotEmpty(t, evt["cwd"])
 	require.NotEmpty(t, evt["cpu"])
 }
 

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -102,6 +102,39 @@ func TestGetState(t *testing.T) {
 		"got process state %q. Last error: %v", got, err)
 }
 
+func TestGetOneRoot(t *testing.T) {
+	testConfig := Stats{
+		Procs:        []string{".*"},
+		Hostfs:       resolve.NewTestResolver("/"),
+		CPUTicks:     false,
+		CacheCmdLine: true,
+		EnvWhitelist: []string{".*"},
+		IncludeTop: IncludeTopConfig{
+			Enabled:  true,
+			ByCPU:    4,
+			ByMemory: 0,
+		},
+		EnableCgroups: false,
+		CgroupOpts: cgroup.ReaderOptions{
+			RootfsMountpoint:  resolve.NewTestResolver("/"),
+			IgnoreRootCgroups: true,
+		},
+	}
+	err := testConfig.Init()
+	assert.NoError(t, err, "Init")
+
+	evt, rootEvt, err := testConfig.GetOneRootEvent(os.Getpid())
+	require.NoError(t, err)
+
+	t.Logf("got event: %s\n root: %s", evt.StringToPrint(), rootEvt.StringToPrint())
+
+	require.NotEmpty(t, rootEvt["process"].(map[string]interface{})["pid"])
+	require.NotEmpty(t, rootEvt["process"].(map[string]interface{})["executable"])
+
+	require.NotEmpty(t, evt["cwd"])
+	require.NotEmpty(t, evt["cpu"])
+}
+
 func TestGetOne(t *testing.T) {
 	testConfig := Stats{
 		Procs:        []string{".*"},

--- a/metric/system/process/process_types.go
+++ b/metric/system/process/process_types.go
@@ -139,6 +139,8 @@ func (t ProcFDInfo) IsZero() bool {
 	return t.Open.IsZero() && t.Limit.Hard.IsZero() && t.Limit.Soft.IsZero()
 }
 
+// FormatForRoot takes the ProcState event and turns the fields into a ProcStateRootEvent
+// struct. These are the root fields expected for events sent from the sytem/process metricset.
 func (p *ProcState) FormatForRoot() ProcStateRootEvent {
 	root := ProcStateRootEvent{}
 

--- a/metric/system/process/process_types.go
+++ b/metric/system/process/process_types.go
@@ -140,7 +140,7 @@ func (t ProcFDInfo) IsZero() bool {
 }
 
 // FormatForRoot takes the ProcState event and turns the fields into a ProcStateRootEvent
-// struct. These are the root fields expected for events sent from the sytem/process metricset.
+// struct. These are the root fields expected for events sent from the system/process metricset.
 func (p *ProcState) FormatForRoot() ProcStateRootEvent {
 	root := ProcStateRootEvent{}
 


### PR DESCRIPTION


## What does this PR do?

This is part of https://github.com/elastic/elastic-agent/issues/4083 

This adds a `GetOneRootEvent()`. method to `ProcStats` we need this for https://github.com/elastic/elastic-agent/issues/4083 , as that issue requires metricbeat's system/process metricset to monitor a specific PID, which it can't do now. This will have to be followed up with a change to beat itself to rope this in. This also cleans up a bit of code and adds some docs.

## Why is it important?

needed for https://github.com/elastic/elastic-agent/issues/4083 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`
