### PR TITLE
Use pointer for processRootevent

### DIFF
--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -122,7 +122,7 @@ func (procStats *Stats) Get() ([]mapstr.M, []mapstr.M, error) {
 		// Add the RSS pct memory first
 		process.Memory.Rss.Pct = GetProcMemPercentage(process, totalPhyMem)
 		// Create the root event
-		rootMap := processRootEvent(process)
+		rootMap := processRootEvent(&process)
 
 		proc, err := procStats.getProcessEvent(&process)
 		if err != nil {
@@ -163,7 +163,7 @@ func (procStats *Stats) GetOneRootEvent(pid int) (mapstr.M, mapstr.M, error) {
 		return nil, nil, fmt.Errorf("error formatting process %d: %w", pid, err)
 	}
 
-	rootMap := processRootEvent(pidStat)
+	rootMap := processRootEvent(&pidStat)
 
 	return procMap, rootMap, err
 }

--- a/metric/system/process/process_common.go
+++ b/metric/system/process/process_common.go
@@ -211,7 +211,7 @@ func (procStats *Stats) Init() error {
 }
 
 // processRootEvent formats the process state event for the ECS root fields used by the system/process metricsets
-func processRootEvent(process ProcState) mapstr.M {
+func processRootEvent(process *ProcState) mapstr.M {
 	// Create the root event
 	root := process.FormatForRoot()
 	rootMap := mapstr.M{}

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -42,6 +42,22 @@ import (
 	"github.com/elastic/elastic-agent-system-metrics/metric/system/resolve"
 )
 
+func TestProcessEvent(t *testing.T) {
+	proc := ProcState{Args: []string{"-b", "-c"},
+		Name:     "test",
+		Username: "user",
+		Memory:   ProcMemInfo{Rss: MemBytePct{Pct: opt.FloatWith(4.5)}},
+	}
+
+	root := processRootEvent(&proc)
+
+	require.Empty(t, proc.Name)
+	require.Empty(t, proc.Username)
+	require.Empty(t, proc.Args)
+
+	require.NotNil(t, root["process"].(map[string]interface{})["memory"])
+}
+
 // BenchmarkGetProcess runs a benchmark of the GetProcess method with caching
 // of the command line and environment variables.
 func BenchmarkGetProcess(b *testing.B) {


### PR DESCRIPTION
## What does this PR do?

This fixes a small bug introduced in #150, where we weren't setting the `ProcState` object while creating the root event.

This is needed for https://github.com/elastic/beats/pull/39620

## Why is it important?

The previous PR adds fields that weren't in events before, this fixes that.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`
