### PR TITLE
refactor: replace multierror with native errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/elastic/go-windows v1.0.1
 	github.com/elastic/gosigar v0.14.2
 	github.com/gofrs/uuid v4.4.0+incompatible
-	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901
 	github.com/magefile/mage v1.15.0
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/shirou/gopsutil/v3 v3.21.12

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,6 @@ github.com/google/licenseclassifier v0.0.0-20200402202327-879cb1424de0/go.mod h1
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
-github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 h1:rp+c0RAYOWj8l6qbCUTSiRLG/iKnW3K3/QfPPuSsBt4=
-github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
 github.com/karrick/godirwalk v1.15.6/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/karrick/godirwalk v1.15.8 h1:7+rWAZPn9zuRxaIqqT8Ohs2Q2Ac0msBqwRdxNCr2VVs=
 github.com/karrick/godirwalk v1.15.8/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=

--- a/metric/cpu/metrics_freebsd.go
+++ b/metric/cpu/metrics_freebsd.go
@@ -19,10 +19,9 @@ package cpu
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/joeshaw/multierror"
 
 	"github.com/elastic/elastic-agent-libs/opt"
 )
@@ -38,7 +37,7 @@ func scanStatFile(scanner *bufio.Scanner) (CPUMetrics, error) {
 func parseCPULine(line string) (CPU, error) {
 	cpuData := CPU{}
 	fields := strings.Fields(line)
-	var errs multierror.Errors
+	var errs []error
 
 	tryParseUint := func(name, field string) (v opt.Uint) {
 		u, err := touint(field)
@@ -55,5 +54,5 @@ func parseCPULine(line string) (CPU, error) {
 	cpuData.Sys = tryParseUint("sys", fields[3])
 	cpuData.Idle = tryParseUint("idle", fields[4])
 
-	return cpuData, errs.Err()
+	return cpuData, errors.Join(errs...)
 }

--- a/metric/cpu/metrics_linux.go
+++ b/metric/cpu/metrics_linux.go
@@ -19,10 +19,9 @@ package cpu
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/joeshaw/multierror"
 
 	"github.com/elastic/elastic-agent-libs/opt"
 )
@@ -37,7 +36,7 @@ func scanStatFile(scanner *bufio.Scanner) (CPUMetrics, error) {
 
 func parseCPULine(line string) (CPU, error) {
 
-	var errs multierror.Errors
+	var errs []error
 	tryParseUint := func(name, field string) (v opt.Uint) {
 		u, err := touint(field)
 		if err != nil {
@@ -60,7 +59,7 @@ func parseCPULine(line string) (CPU, error) {
 	cpuData.SoftIrq = tryParseUint("softirq", fields[7])
 	cpuData.Stolen = tryParseUint("stolen", fields[8])
 
-	return cpuData, errs.Err()
+	return cpuData, errors.Join(errs...)
 }
 
 func scanCPUInfoFile(scanner *bufio.Scanner) ([]CPUInfo, error) {


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Go 1.20 added support for wrapping multiple errors. Drop multierror library and use stdlib errors

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

