### PR TITLE
Use core-windows-2022 instead of unmaintained ci-windows-2022

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@
 env:
   SETUP_GVM_VERSION: 'v0.5.2'
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
-  WINDOWS_AGENT_IMAGE: "family/ci-windows-2022"
+  WINDOWS_AGENT_IMAGE: "family/core-windows-2022"
 
 steps:
   - label: ":golangci-lint: Lint"


### PR DESCRIPTION
## What does this PR do?
The image family `ci-windows-2022` used by the build agent has been unmaintained for a while and has been replaced by `core-windows-2022`. This PR updates them to this instead.

Related to [incident 505.](https://elastic.slack.com/archives/C078RND5G5C)

## Why is it important?
To mitigate issues from incident 505.](https://elastic.slack.com/archives/C078RND5G5C)



