### PR TITLE
fix: move non-fatal error to helpers

### DIFF
--- a/metric/system/process/helpers.go
+++ b/metric/system/process/helpers.go
@@ -99,6 +99,33 @@ func GetProcCPUPercentage(s0, s1 ProcState) ProcState {
 
 }
 
+// NonFatalErr is returned when there was an error
+// collecting metrics, however the metrics already
+// gathered and returned are still valid.
+// This error can be safely ignored, this will result
+// in having partial metrics for a process rather than
+// no metrics at all.
+//
+// It was introduced to allow for partial metrics collection
+// on privileged process on Windows.
+type NonFatalErr struct {
+	Err error
+}
+
+func (c NonFatalErr) Error() string {
+	return "Not enough privileges to fetch information: " + c.Err.Error()
+}
+
+func (c NonFatalErr) Is(other error) bool {
+	_, is := other.(NonFatalErr)
+	return is
+}
+
+func (c NonFatalErr) Unwrap() error {
+	return c.Err
+}
+
+// Wraps a NonFatalError around a generic error, if given error is non-fatal in nature
 func toNonFatal(err error) error {
 	if err == nil {
 		return nil

--- a/metric/system/process/helpers.go
+++ b/metric/system/process/helpers.go
@@ -99,8 +99,8 @@ func GetProcCPUPercentage(s0, s1 ProcState) ProcState {
 
 }
 
-// NonFatalErr is returned when there was an error
-// collecting metrics, however the metrics already
+// NonFatalErr indicates an error occurred during metrics
+// collection, however the metrics already
 // gathered and returned are still valid.
 // This error can be safely ignored, this will result
 // in having partial metrics for a process rather than

--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -218,32 +218,6 @@ func (procStats *Stats) pidIter(pid int, procMap ProcsMap, proclist []ProcState)
 	return procMap, proclist, nonFatalErr
 }
 
-// NonFatalErr is returned when there was an error
-// collecting metrics, however the metrics already
-// gathered and returned are still valid.
-// This error can be safely ignored, this will result
-// in having partial metrics for a process rather than
-// no metrics at all.
-//
-// It was introduced to allow for partial metrics collection
-// on privileged process on Windows.
-type NonFatalErr struct {
-	Err error
-}
-
-func (c NonFatalErr) Error() string {
-	return "Not enough privileges to fetch information: " + c.Err.Error()
-}
-
-func (c NonFatalErr) Is(other error) bool {
-	_, is := other.(NonFatalErr)
-	return is
-}
-
-func (c NonFatalErr) Unwrap() error {
-	return c.Err
-}
-
 // pidFill is an entrypoint used by OS-specific code to fill out a pid.
 // This in turn calls various OS-specific code to fill out the various bits of PID data
 // This is done to minimize the code duplication between different OS implementations


### PR DESCRIPTION
- Bug
## What does this PR do?

A quick fix PR to move `NonFatalErr` to helpers.go instead of process.go.
This makes sure that `NonFatalErr` compiles for all OS'.
## Why is it important?

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

