### PR TITLE
Comply with ECS for `host.name`

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -846,11 +846,11 @@ Contents of probable licence file $GOMODCACHE/github.com/elastic/go-structform@v
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/go-sysinfo
-Version: v1.14.0
+Version: v1.14.1
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/go-sysinfo@v1.14.0/LICENSE.txt:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/go-sysinfo@v1.14.1/LICENSE.txt:
 
 
                                  Apache License
@@ -1480,12 +1480,12 @@ limitations under the License.
 
 
 --------------------------------------------------------------------------------
-Dependency : github.com/gofrs/uuid
-Version: v4.4.0+incompatible
+Dependency : github.com/gofrs/uuid/v5
+Version: v5.2.0
 Licence type (autodetected): MIT
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/gofrs/uuid@v4.4.0+incompatible/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/gofrs/uuid/v5@v5.2.0/LICENSE:
 
 Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
 
@@ -3241,6 +3241,36 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+--------------------------------------------------------------------------------
+Dependency : github.com/gofrs/uuid
+Version: v4.4.0+incompatible
+Licence type (autodetected): MIT
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/github.com/gofrs/uuid@v4.4.0+incompatible/LICENSE:
+
+Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 --------------------------------------------------------------------------------

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/elastic/elastic-agent-libs v0.9.13
 	github.com/elastic/go-licenser v0.4.2
 	github.com/elastic/go-structform v0.0.9
-	github.com/elastic/go-sysinfo v1.14.0
+	github.com/elastic/go-sysinfo v1.14.1
 	github.com/elastic/go-windows v1.0.1
 	github.com/elastic/gosigar v0.14.2
 	github.com/gofrs/uuid/v5 v5.2.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/elastic/go-licenser v0.4.2 h1:bPbGm8bUd8rxzSswFOqvQh1dAkKGkgAmrPxbUi+
 github.com/elastic/go-licenser v0.4.2/go.mod h1:W8eH6FaZDR8fQGm+7FnVa7MxI1b/6dAqxz+zPB8nm5c=
 github.com/elastic/go-structform v0.0.9 h1:HpcS7xljL4kSyUfDJ8cXTJC6rU5ChL1wYb6cx3HLD+o=
 github.com/elastic/go-structform v0.0.9/go.mod h1:CZWf9aIRYY5SuKSmOhtXScE5uQiLZNqAFnwKR4OrIM4=
-github.com/elastic/go-sysinfo v1.14.0 h1:dQRtiqLycoOOla7IflZg3aN213vqJmP0lpVpKQ9lUEY=
-github.com/elastic/go-sysinfo v1.14.0/go.mod h1:FKUXnZWhnYI0ueO7jhsGV3uQJ5hiz8OqM5b3oGyaRr8=
+github.com/elastic/go-sysinfo v1.14.1 h1:BpY/Utfz75oKSpsQnbAJmmlnT3gBV9WFsopBEYgjhZY=
+github.com/elastic/go-sysinfo v1.14.1/go.mod h1:FKUXnZWhnYI0ueO7jhsGV3uQJ5hiz8OqM5b3oGyaRr8=
 github.com/elastic/go-ucfg v0.8.8 h1:54KIF/2zFKfl0MzsSOCGOsZ3O2bnjFQJ0nDJcLhviyk=
 github.com/elastic/go-ucfg v0.8.8/go.mod h1:4E8mPOLSUV9hQ7sgLEJ4bvt0KhMuDJa8joDT2QGAEKA=
 github.com/elastic/go-windows v1.0.1 h1:AlYZOldA+UJ0/2nBuqWdo90GFCgG9xuyw9SYzGUtJm0=

--- a/metric/system/host/host.go
+++ b/metric/system/host/host.go
@@ -18,6 +18,8 @@
 package host
 
 import (
+	"strings"
+
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 	"github.com/elastic/go-sysinfo"
@@ -33,7 +35,7 @@ func MapHostInfo(info types.HostInfo, fqdn string) mapstr.M {
 
 	data := mapstr.M{
 		"host": mapstr.M{
-			"name":         name,
+			"name":         strings.ToLower(name),
 			"hostname":     info.Hostname,
 			"architecture": info.Architecture,
 			"os": mapstr.M{

--- a/metric/system/host/host_test.go
+++ b/metric/system/host/host_test.go
@@ -46,7 +46,7 @@ func TestMapHostInfo(t *testing.T) {
 		Architecture:      "x86_64",
 		BootTime:          bootTime,
 		Containerized:     &containerized,
-		Hostname:          "foo",
+		Hostname:          "fOo",
 		IPs:               []string{"1.2.3.4", "192.168.1.1"},
 		KernelVersion:     "22.3.0",
 		MACs:              []string{"56:9c:17:54:19:15", "5c:e9:1e:c4:37:66"},
@@ -66,7 +66,7 @@ func TestMapHostInfo(t *testing.T) {
 				"host": mapstr.M{
 					"architecture":  "x86_64",
 					"containerized": true,
-					"hostname":      "foo",
+					"hostname":      "fOo",
 					"id":            "a39b4c1ee4",
 					"name":          "foo.bar.local",
 					"os": mapstr.M{
@@ -87,7 +87,7 @@ func TestMapHostInfo(t *testing.T) {
 				"host": mapstr.M{
 					"architecture":  "x86_64",
 					"containerized": true,
-					"hostname":      "foo",
+					"hostname":      "fOo",
 					"id":            "a39b4c1ee4",
 					"name":          "foo",
 					"os": mapstr.M{


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Upgrades go-sysinfo to v1.14.1, which does not lower-case the FQDN. Therefore, `host.name` returned by  `host.MapHostInfo` is lower-cased to comply with [ECS](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-name).

## Why is it important?

The FQDN should not be lower-cased by default and the `host.hostname`, when set to FQDN, should be the FQDN as defined in the system.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.md`

## Related issues

- Relates https://github.com/elastic/beats/issues/39993

