### PR TITLE
Change cgroups log line from `Infof` from `Debugf`

### DIFF
--- a/metric/system/cgroup/util.go
+++ b/metric/system/cgroup/util.go
@@ -477,7 +477,7 @@ func (r *Reader) ProcessCgroupPaths(pid int) (PathList, error) {
 				logp.L().Debugf("cgroup for process %d contains a relative cgroup path (%s), but we were not able to find a root cgroup. Cgroup monitoring for this PID may be incomplete",
 					pid, path)
 			} else {
-				logp.L().Infof("using root mount %s and path %s", r.cgroupMountpoints.ContainerizedRootMount, path)
+				logp.L().Debugf("using root mount %s and path %s", r.cgroupMountpoints.ContainerizedRootMount, path)
 				path = filepath.Join(r.cgroupMountpoints.ContainerizedRootMount, path)
 			}
 		}


### PR DESCRIPTION
## What does this PR do?

This is a one-liner that removes an erroneous `Infof()` debug line that should have been a `Debugf()` line. 

## Why is it important?

This can create lots of logging noise.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
