### PR TITLE
fix non-fatal error tests

### DIFF
--- a/metric/system/process/helpers.go
+++ b/metric/system/process/helpers.go
@@ -113,7 +113,10 @@ type NonFatalErr struct {
 }
 
 func (c NonFatalErr) Error() string {
-	return "Not enough privileges to fetch information: " + c.Err.Error()
+	if c.Err != nil {
+		return "Not enough privileges to fetch information: " + c.Err.Error()
+	}
+	return "Not enough privileges to fetch information"
 }
 
 func (c NonFatalErr) Is(other error) bool {

--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -205,7 +205,7 @@ func (procStats *Stats) pidIter(pid int, procMap ProcsMap, proclist []ProcState)
 			}
 			return procMap, proclist, err
 		}
-		nonFatalErr = fmt.Errorf("non fatal error fetching PID some info for %d, metrics are valid, but partial: %w", pid, err)
+		nonFatalErr = NonFatalErr{Err: fmt.Errorf("non fatal error fetching PID some info for %d, metrics are valid, but partial: %w", pid, err)}
 		procStats.logger.Debugf(err.Error())
 	}
 	if !saved {

--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -206,7 +206,7 @@ func (procStats *Stats) pidIter(pid int, procMap ProcsMap, proclist []ProcState)
 			}
 			return procMap, proclist, err
 		}
-		nonFatalErr = NonFatalErr{Err: fmt.Errorf("non fatal error fetching PID some info for %d, metrics are valid, but partial: %w", pid, err)}
+		nonFatalErr = fmt.Errorf("non fatal error fetching PID some info for %d, metrics are valid, but partial: %w", pid, err)
 		procStats.logger.Debugf(err.Error())
 	}
 	if !saved {

--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -192,6 +192,7 @@ func (procStats *Stats) GetSelf() (ProcState, error) {
 
 // pidIter wraps a few lines of generic code that all OS-specific FetchPids() functions must call.
 // this also handles the process of adding to the maps/lists in order to limit the code duplication in all the OS implementations
+// NOTE: this method will sometimes return a NonFatalError{} wrapper for errors that can optionally be ignored.
 func (procStats *Stats) pidIter(pid int, procMap ProcsMap, proclist []ProcState) (ProcsMap, []ProcState, error) {
 	status, saved, err := procStats.pidFill(pid, true)
 	var nonFatalErr error

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -60,7 +60,9 @@ func TestFetchOtherProcessCgroup(t *testing.T) {
 	assert.NoError(t, err, "Init")
 
 	evts, _, err := testConfig.Get()
-	assert.ErrorIs(t, err, NonFatalErr{})
+	if err != nil {
+		assert.ErrorIs(t, err, NonFatalErr{})
+	}
 	t.Logf("Got %d events", len(evts))
 }
 
@@ -192,7 +194,9 @@ func TestCgroupsBadCgroupsConfig(t *testing.T) {
 
 	// make sure we still have proc data despite cgroups errors
 	procs, _, err := testStats.Get()
-	assert.ErrorIs(t, err, NonFatalErr{})
+	if err != nil {
+		assert.ErrorIs(t, err, NonFatalErr{})
+	}
 
 	t.Logf("got %d procs", len(procs))
 	require.NotEmpty(t, procs)

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -20,6 +20,7 @@
 package process
 
 import (
+	"errors"
 	"os"
 	"os/user"
 	"strconv"
@@ -60,7 +61,11 @@ func TestFetchOtherProcessCgroup(t *testing.T) {
 	assert.NoError(t, err, "Init")
 
 	evts, _, err := testConfig.Get()
-	require.NoError(t, err)
+	if err != nil {
+		assert.True(t, errors.Is(err, NonFatalErr{}))
+	} else {
+		assert.NoError(t, err, "GetOne with one event")
+	}
 	t.Logf("Got %d events", len(evts))
 }
 
@@ -192,7 +197,11 @@ func TestCgroupsBadCgroupsConfig(t *testing.T) {
 
 	// make sure we still have proc data despite cgroups errors
 	procs, _, err := testStats.Get()
-	require.NoError(t, err)
+	if err != nil {
+		assert.True(t, errors.Is(err, NonFatalErr{}))
+	} else {
+		assert.NoError(t, err, "GetOne with one event")
+	}
 	t.Logf("got %d procs", len(procs))
 	require.NotEmpty(t, procs)
 

--- a/metric/system/process/process_linux_test.go
+++ b/metric/system/process/process_linux_test.go
@@ -20,7 +20,6 @@
 package process
 
 import (
-	"errors"
 	"os"
 	"os/user"
 	"strconv"
@@ -61,11 +60,7 @@ func TestFetchOtherProcessCgroup(t *testing.T) {
 	assert.NoError(t, err, "Init")
 
 	evts, _, err := testConfig.Get()
-	if err != nil {
-		assert.True(t, errors.Is(err, NonFatalErr{}))
-	} else {
-		assert.NoError(t, err, "GetOne with one event")
-	}
+	assert.ErrorIs(t, err, NonFatalErr{})
 	t.Logf("Got %d events", len(evts))
 }
 
@@ -197,11 +192,8 @@ func TestCgroupsBadCgroupsConfig(t *testing.T) {
 
 	// make sure we still have proc data despite cgroups errors
 	procs, _, err := testStats.Get()
-	if err != nil {
-		assert.True(t, errors.Is(err, NonFatalErr{}))
-	} else {
-		assert.NoError(t, err, "GetOne with one event")
-	}
+	assert.ErrorIs(t, err, NonFatalErr{})
+
 	t.Logf("got %d procs", len(procs))
 	require.NotEmpty(t, procs)
 

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -21,7 +21,6 @@ package process
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -242,11 +241,7 @@ func TestFilter(t *testing.T) {
 	assert.NoError(t, err, "Init")
 
 	procData, _, err := testConfig.Get()
-	if err != nil {
-		assert.True(t, errors.Is(err, NonFatalErr{}))
-	} else {
-		assert.NoError(t, err, "GetOne with one event")
-	}
+	assert.ErrorIs(t, err, NonFatalErr{})
 	// the total count of processes can either be one or two,
 	// depending on if the highest-mem-usage process and
 	// highest-cpu-usage process are the same.
@@ -266,11 +261,7 @@ func TestFilter(t *testing.T) {
 	assert.NoError(t, err, "Init")
 
 	oneData, _, err := testZero.Get()
-	if err != nil {
-		assert.True(t, errors.Is(err, NonFatalErr{}))
-	} else {
-		assert.NoError(t, err, "GetOne with one event")
-	}
+	assert.ErrorIs(t, err, NonFatalErr{})
 
 	assert.Equal(t, 1, len(oneData))
 }

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -241,7 +241,10 @@ func TestFilter(t *testing.T) {
 	assert.NoError(t, err, "Init")
 
 	procData, _, err := testConfig.Get()
-	assert.ErrorIs(t, err, NonFatalErr{})
+	if err != nil {
+		assert.ErrorIs(t, err, NonFatalErr{})
+	}
+
 	// the total count of processes can either be one or two,
 	// depending on if the highest-mem-usage process and
 	// highest-cpu-usage process are the same.
@@ -261,14 +264,18 @@ func TestFilter(t *testing.T) {
 	assert.NoError(t, err, "Init")
 
 	oneData, _, err := testZero.Get()
-	assert.ErrorIs(t, err, NonFatalErr{})
+	if err != nil {
+		assert.ErrorIs(t, err, NonFatalErr{})
+	}
 
 	assert.Equal(t, 1, len(oneData))
 }
 
 func TestProcessList(t *testing.T) {
 	plist, err := ListStates(resolve.NewTestResolver("/"))
-	assert.True(t, isNonFatal(err), fmt.Sprintf("Fatal Error: %s", err))
+	if err != nil {
+		assert.ErrorIs(t, err, NonFatalErr{})
+	}
 
 	for _, proc := range plist {
 		assert.NotEmpty(t, proc.State)

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -21,6 +21,7 @@ package process
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -241,7 +242,11 @@ func TestFilter(t *testing.T) {
 	assert.NoError(t, err, "Init")
 
 	procData, _, err := testConfig.Get()
-	assert.NoError(t, err, "GetOne")
+	if err != nil {
+		assert.True(t, errors.Is(err, NonFatalErr{}))
+	} else {
+		assert.NoError(t, err, "GetOne with one event")
+	}
 	// the total count of processes can either be one or two,
 	// depending on if the highest-mem-usage process and
 	// highest-cpu-usage process are the same.
@@ -261,7 +266,12 @@ func TestFilter(t *testing.T) {
 	assert.NoError(t, err, "Init")
 
 	oneData, _, err := testZero.Get()
-	assert.NoError(t, err, "GetOne with one event")
+	if err != nil {
+		assert.True(t, errors.Is(err, NonFatalErr{}))
+	} else {
+		assert.NoError(t, err, "GetOne with one event")
+	}
+
 	assert.Equal(t, 1, len(oneData))
 }
 


### PR DESCRIPTION
## What does this PR do?

So, a previous PR changed the behavior of the process code such that we're now returning non-fatal errors. 
However, a bunch of the tests were not updated, and are now failing. 

I'm a little worried by the fact that none of the tests failed initially, as they fail when I run them locally. Part of the problem is that the CI environment often doesn't have any processes running as other users, meaning we won't hit a lot of code that deals with permissions errors. Still, it feels like _something_ should have failed here. Still investigating. 

## Why is it important?

This is causing tests here to fail: https://github.com/elastic/beats/pull/40507

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`

