### PR TITLE
github-action: use oblt-actions/git/setup

### DIFF
--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Git
-        uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
+        uses: elastic/oblt-actions/git/setup@v1
 
       - name: Install Updatecli in the runner
         uses: updatecli/updatecli-action@22fc20fc94d2482874876b66b797e2a4a7178445


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

NOTE: https://github.com/elastic/apm-pipeline-library has been deprecated in favor of 
https://github.com/elastic/oblt-actions.

If there are any questions, please reach out to the @elastic/observablt-ci
