### PR TITLE
[windows][system/process] - Get Idle process' stats

### DIFF
--- a/metric/system/process/zsyscall_windows.go
+++ b/metric/system/process/zsyscall_windows.go
@@ -56,6 +56,7 @@ func errnoErr(e syscall.Errno) error {
 
 var (
 	modkernel32 = windows.NewLazySystemDLL("kernel32.dll")
+	ntdll  		= windows.NewLazySystemDLL("ntdll.dll")
 
 	procPssCaptureSnapshot = modkernel32.NewProc("PssCaptureSnapshot")
 	procPssQuerySnapshot   = modkernel32.NewProc("PssQuerySnapshot")


### PR DESCRIPTION
- Enhancement

## What does this PR do?

This PR adds two functions that captures following information for idle process (pid 0). This is the only way I came across as we cannot open process handle for pid 0.
- memory stats
- CPU usage
- number of threads

Future PR:
- In a follow up PR, I'll fix metric collection for PID 4.
- The a final PR to integrate changes and update the final process map to include PID 0 and 4.
- Then, we can merge it to main after testing it thoroughly.

## Why is it important?

- See https://github.com/elastic/beats/issues/40484 for more info

## NOTE:

I've created a dedicated branch called `windows-protected-processes` to hold all the changes. Once we made the necessary updates for protected process, I'll test them manually and then submit a final PR to merge it into the `main` branch. I think this is the best approach to avoid any issues and CI failures due to releases. Let me know your thoughts!
