### PR TITLE
[chore][windows][system/process]: ignore error in some cases

### DIFF
--- a/metric/system/process/process_windows.go
+++ b/metric/system/process/process_windows.go
@@ -265,6 +265,8 @@ func getProcName(pid int) (string, error) {
 	}()
 
 	filename, err := windows.GetProcessImageFileName(handle)
+
+	//nolint:nilerr // safe to ignore this error
 	if err != nil {
 		// if we're able to open the handle but GetProcessImageFileName fails then it most probably means
 		// that the process doesn't have any executable associated with it.

--- a/metric/system/process/process_windows.go
+++ b/metric/system/process/process_windows.go
@@ -136,8 +136,9 @@ func FillPidMetrics(_ resolve.Resolver, pid int, state ProcState, _ func(string)
 	user, _ := getProcCredName(pid)
 	state.Username = user // we cannot access process token for system-owned protected processes
 
-	ppid, _ := getParentPid(pid)
-	state.Ppid = opt.IntWith(ppid)
+	if ppid, err := getParentPid(pid); err == nil {
+		state.Ppid = opt.IntWith(ppid)
+	}
 
 	wss, size, err := procMem(pid)
 	if err != nil {

--- a/metric/system/process/process_windows.go
+++ b/metric/system/process/process_windows.go
@@ -268,9 +268,12 @@ func getProcName(pid int) (string, error) {
 
 	//nolint:nilerr // safe to ignore this error
 	if err != nil {
-		// if we're able to open the handle but GetProcessImageFileName fails then it most probably means
-		// that the process doesn't have any executable associated with it.
-		return "", nil
+		if isNonFatal(err) {
+			// if we're able to open the handle but GetProcessImageFileName fails with access denied error
+			// that the process doesn't have any executable associated with it.
+			return "", nil
+		}
+		return "", err
 	}
 
 	return filepath.Base(filename), nil


### PR DESCRIPTION
- Enhancement

We can ignore the error in two cases:
- While reading the process executable name. 
    - For pid 4, this call fails as we can't access the executable name via the system call. Same for other kernel-level processes.
- While finding the owner for a particular process.
    - We try to open the process token via `syscall.OpenProcessToken`and we can't access the token for protected processes , even as an administrator. 
    
it's okay to ignore these errors and move forward as we can access few other metrics (memory, cpu).
    
More context [here](https://github.com/elastic/beats/issues/40484#issuecomment-2400100817)

Relates https://github.com/elastic/beats/issues/40484 