### PR TITLE
[system/process] - Add idle process' stats

### DIFF
--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -282,7 +282,7 @@ func (procStats *Stats) pidFill(pid int, filter bool) (ProcState, bool, error) {
 
 	status, err = FillMetricsRequiringMoreAccess(pid, status)
 	if err != nil {
-		return status, true, fmt.Errorf("FillMetricsRequiringMoreAccess: %w", err)
+		procStats.logger.Debugf("error calling FillMetricsRequiringMoreAccess for pid %d: %w", pid, err)
 	}
 
 	// Generate `status.Cmdline` here for compatibility because on Windows

--- a/metric/system/process/process_windows.go
+++ b/metric/system/process/process_windows.go
@@ -463,12 +463,16 @@ func fillIdleProcess(state ProcState) (ProcState, error) {
 	if err != nil {
 		return state, err
 	}
-	time.Sleep(500 * time.Millisecond)
+	// sleep is cruical to calculate the idle percentage
+	time.Sleep(50 * time.Millisecond)
 	total1, idle1, err := getIdleProcessTime()
 	if err != nil {
 		return state, err
 	}
-	state.CPU.Total.Pct = opt.FloatWith((idle1 - idle0) / (total1 - total0))
+	// Check if denominator is non-zero, to avoid "invalid operation: division by zero"
+	if total1-total0 != 0 {
+		state.CPU.Total.Pct = opt.FloatWith((idle1 - idle0) / (total1 - total0))
+	}
 	state.CPU.Total.Ticks = opt.UintWith(uint64(idle1 / 1e6))
 	state.CPU.Total.Value = opt.FloatWith(idle1)
 	return state, nil

--- a/metric/system/process/process_windows.go
+++ b/metric/system/process/process_windows.go
@@ -431,8 +431,9 @@ func getIdleProcessMemory(state ProcState) (ProcState, error) {
 	var returnLength uint32
 
 	_, _, err := ntQuerySystemInformation.Call(xsyswindows.SystemProcessInformation, uintptr(unsafe.Pointer(&systemInfo[0])), uintptr(len(systemInfo)), uintptr(unsafe.Pointer(&returnLength)))
-	// NtQuerySystemInformation return "operation permitted sucessfully" i.e. errorno 0. We can ignore this error.
-	if err != nil && err != syscall.Errno(0) {
+	// NtQuerySystemInformation returns "operation permitted successfully"(i.e. errorno 0) on success.
+	// Hence, we can ignore syscall.Errno(0).
+	if err != nil && !errors.Is(err, syscall.Errno(0)) {
 		return state, toNonFatal(err)
 	}
 


### PR DESCRIPTION
This PR does the following:
- It integrates `getIdleMemory` and `getProcessMemory` introduced in https://github.com/elastic/elastic-agent-system-metrics/pull/181. This is used to capture stats for PID 0.
- `FillMetricsRequiringMoreAccess` adds some extra information about a process. It's failure is expected for protected processes and if a non-root user accesses elevated processes. We can just log the error rather than returning an error. This will not pollute the status message on fleet.
     - @cmacknz Please let me know how you feel about this.

This is final PR in this series and once this PR gets merged, we can merge `windows-protected-processes` into `main`.