### PR TITLE
[bugfix][system/process] continue if we encounter an error, or it'll lead to panic

### DIFF
--- a/metric/system/process/process_darwin.go
+++ b/metric/system/process/process_darwin.go
@@ -234,6 +234,7 @@ func getProcArgs(pid int, filter func(string) bool) ([]string, string, mapstr.M,
 			// invalid k-v pair encountered, return non-fatal error so that we can continue
 			err := fmt.Errorf("error reading process information from KERN_PROCARGS2: encountered invalid env pair for pid %d", pid)
 			envErr = errors.Join(envErr, NonFatalErr{Err: err})
+			continue
 		}
 		eKey := string(pair[0])
 		if filter == nil || filter(eKey) {


### PR DESCRIPTION
 continue if we encounter an error, or it'll lead to panic here https://github.com/elastic/elastic-agent-system-metrics/blob/ef8d2d0a7e9e0a64a427b190b8c113141f1a99dc/metric/system/process/process_darwin.go#L240-L242
 
 We return an error if we env pairs are invalid. See https://github.com/elastic/elastic-agent-system-metrics/pull/186.
 `Continue` if we face error.