### PR TITLE
[chore][process] narrow the log that is passed to the caller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.8
 
 require (
 	github.com/docker/docker v26.1.5+incompatible
-	github.com/elastic/elastic-agent-libs v0.17.4-0.20241126154321-6ed75416832d
+	github.com/elastic/elastic-agent-libs v0.17.4
 	github.com/elastic/go-licenser v0.4.2
 	github.com/elastic/go-structform v0.0.9
 	github.com/elastic/go-sysinfo v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKoh
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/elastic/elastic-agent-libs v0.17.4-0.20241126154321-6ed75416832d h1:nY8LSeTYU1uSDAAg7WwGH/cALgdovAXLdIzV25Ky0Bo=
-github.com/elastic/elastic-agent-libs v0.17.4-0.20241126154321-6ed75416832d/go.mod h1:5CR02awPrBr+tfmjBBK+JI+dMmHNQjpVY24J0wjbC7M=
+github.com/elastic/elastic-agent-libs v0.17.4 h1:kWK5Kn2EQjM97yHqbeXv+cFAIti4IiI9Qj8huM+lZzE=
+github.com/elastic/elastic-agent-libs v0.17.4/go.mod h1:5CR02awPrBr+tfmjBBK+JI+dMmHNQjpVY24J0wjbC7M=
 github.com/elastic/go-licenser v0.4.2 h1:bPbGm8bUd8rxzSswFOqvQh1dAkKGkgAmrPxbUi+Y9+A=
 github.com/elastic/go-licenser v0.4.2/go.mod h1:W8eH6FaZDR8fQGm+7FnVa7MxI1b/6dAqxz+zPB8nm5c=
 github.com/elastic/go-structform v0.0.9 h1:HpcS7xljL4kSyUfDJ8cXTJC6rU5ChL1wYb6cx3HLD+o=

--- a/metric/system/process/helpers.go
+++ b/metric/system/process/helpers.go
@@ -114,9 +114,9 @@ type NonFatalErr struct {
 
 func (c NonFatalErr) Error() string {
 	if c.Err != nil {
-		return "Not enough privileges to fetch information: " + c.Err.Error()
+		return "non fatal error; reporting partial metrics: " + c.Err.Error()
 	}
-	return "Not enough privileges to fetch information"
+	return "non fatal error"
 }
 
 func (c NonFatalErr) Is(other error) bool {

--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -138,7 +138,7 @@ func (procStats *Stats) Get() ([]mapstr.M, []mapstr.M, error) {
 	}
 	if len(failedPIDs) > 0 {
 		procStats.logger.Debugf("error fetching process metrics: %v", wrappedErr)
-		return procs, rootEvents, NonFatalErr{Err: errors.New(fmt.Sprintf(errFetchingPIDs, len(failedPIDs)))}
+		return procs, rootEvents, NonFatalErr{Err: fmt.Errorf(errFetchingPIDs, len(failedPIDs))}
 	}
 	return procs, rootEvents, nil
 }

--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -213,7 +213,7 @@ func (procStats *Stats) pidIter(pid int, procMap ProcsMap, proclist []ProcState)
 			}
 			return procMap, proclist, err
 		}
-		nonFatalErr = fmt.Errorf("non fatal error fetching PID some info for %d, metrics are valid, but partial: %w", pid, err)
+		nonFatalErr = fmt.Errorf("error for pid %d: %w", pid, err)
 		procStats.logger.Debugf(err.Error())
 	}
 	if !saved {
@@ -259,7 +259,7 @@ func (procStats *Stats) pidFill(pid int, filter bool) (ProcState, bool, error) {
 		if !errors.Is(err, NonFatalErr{}) {
 			return status, true, fmt.Errorf("FillPidMetrics failed for PID %d: %w", pid, err)
 		}
-		wrappedErr = errors.Join(wrappedErr, fmt.Errorf("non-fatal error fetching PID metrics for %d, metrics are valid, but partial: %w", pid, err))
+		wrappedErr = errors.Join(wrappedErr, err)
 		procStats.logger.Debugf(wrappedErr.Error())
 	}
 

--- a/metric/system/process/process_types.go
+++ b/metric/system/process/process_types.go
@@ -56,6 +56,9 @@ type ProcState struct {
 
 	// meta
 	SampleTime time.Time `struct:"-,omitempty"`
+
+	// boolean to indicate that given PID has failed due to some error.
+	Failed bool `struct:"-,omitempty"`
 }
 
 // ProcCPUInfo is the main struct for CPU metrics


### PR DESCRIPTION
This is to reduce the log pollution in default case. If the user is interested to view the full log, they can enable "debug" logging.

Closes https://github.com/elastic/beats/issues/41890