### PR TITLE
[process/windows] - Ignore accessing command line arguments for selected processes (currently, lsass.exe)

### DIFF
--- a/metric/system/process/helpers_others.go
+++ b/metric/system/process/helpers_others.go
@@ -33,3 +33,7 @@ func isNonFatal(err error) bool {
 		errors.Is(err, syscall.EINVAL) ||
 		errors.Is(err, NonFatalErr{}))
 }
+
+func processesToIgnore() (m map[uint64]struct{}) {
+	return
+}

--- a/metric/system/process/helpers_others.go
+++ b/metric/system/process/helpers_others.go
@@ -34,6 +34,6 @@ func isNonFatal(err error) bool {
 		errors.Is(err, NonFatalErr{}))
 }
 
-func processesToIgnore() (m map[uint64]struct{}) {
-	return m
+func processesToIgnore() map[uint64]struct{} {
+	return map[uint64]struct{}{}
 }

--- a/metric/system/process/helpers_others.go
+++ b/metric/system/process/helpers_others.go
@@ -35,5 +35,5 @@ func isNonFatal(err error) bool {
 }
 
 func processesToIgnore() (m map[uint64]struct{}) {
-	return
+	return m
 }

--- a/metric/system/process/helpers_windows.go
+++ b/metric/system/process/helpers_windows.go
@@ -23,9 +23,10 @@ import (
 	"errors"
 	"syscall"
 
-	"github.com/elastic/elastic-agent-libs/logp"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
+
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func isNonFatal(err error) bool {

--- a/metric/system/process/helpers_windows.go
+++ b/metric/system/process/helpers_windows.go
@@ -39,7 +39,8 @@ func isNonFatal(err error) bool {
 		errors.Is(err, windows.ERROR_INVALID_PARAMETER) || errors.Is(err, NonFatalErr{})
 }
 
-func processesToIgnore() (m map[uint64]struct{}) {
+func processesToIgnore() map[uint64]struct{} {
+	m := make(map[uint64]struct{})
 	// processesToIgnore checks if we should ignore the pid, to avoid elevated permissions
 
 	// LSASS.exe is a process which has no useful cmdline arguments, we should ignore acessing such process to avoid triggering Windows ASR rules

--- a/metric/system/process/helpers_windows.go
+++ b/metric/system/process/helpers_windows.go
@@ -55,5 +55,5 @@ func processesToIgnore() (m map[uint64]struct{}) {
 		return m
 	}
 	m[lsassPid] = struct{}{}
-	return
+	return m
 }

--- a/metric/system/process/helpers_windows.go
+++ b/metric/system/process/helpers_windows.go
@@ -47,7 +47,7 @@ func processesToIgnore() map[uint64]struct{} {
 	// we can query pid for LASASS.exe from registry
 	key, err := registry.OpenKey(registry.LOCAL_MACHINE, "SYSTEM\\CurrentControlSet\\Control\\Lsa", registry.READ)
 	if err != nil {
-		logp.L().Warnw("Failed to read registry path SYSTEM\\CurrentControlSet\\Control\\Lsa", "error", err)
+		logp.L().Warnw("Failed to open registry path SYSTEM\\CurrentControlSet\\Control\\Lsa", "error", err)
 		return m
 	}
 	defer key.Close()

--- a/metric/system/process/helpers_windows.go
+++ b/metric/system/process/helpers_windows.go
@@ -39,7 +39,7 @@ func isNonFatal(err error) bool {
 }
 
 func processesToIgnore() (m map[uint64]struct{}) {
-	// shouldIgnore checks if we should ignore the pid, to avoid elevated permissions
+	// processesToIgnore checks if we should ignore the pid, to avoid elevated permissions
 
 	// LSASS.exe is a process which has no useful cmdline arguments, we should ignore acessing such process to avoid triggering Windows ASR rules
 	// we can query pid for LASASS.exe from registry

--- a/metric/system/process/helpers_windows.go
+++ b/metric/system/process/helpers_windows.go
@@ -51,7 +51,7 @@ func processesToIgnore() map[uint64]struct{} {
 		return m
 	}
 	defer key.Close()
-	lsassPid, _, err := key.GetIntegerValue("LasPid")
+	lsassPid, _, err := key.GetIntegerValue("LsaPid")
 	if err != nil {
 		logp.L().Warnw("Failed to read pid for lsass.exe", "error", err)
 		return m

--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -291,15 +291,17 @@ func (procStats *Stats) pidFill(pid int, filter bool) (ProcState, bool, error) {
 
 	} // end cgroups processor
 
-	status, err = FillMetricsRequiringMoreAccess(pid, status)
-	if err != nil {
-		procStats.logger.Debugf("error calling FillMetricsRequiringMoreAccess for pid %d: %w", pid, err)
-	}
+	if _, ok := procStats.excludedPIDs[uint64(pid)]; !ok {
+		status, err = FillMetricsRequiringMoreAccess(pid, status)
+		if err != nil {
+			procStats.logger.Debugf("error calling FillMetricsRequiringMoreAccess for pid %d: %w", pid, err)
+		}
 
-	// Generate `status.Cmdline` here for compatibility because on Windows
-	// `status.Args` is set by `FillMetricsRequiringMoreAccess`.
-	if len(status.Args) > 0 && status.Cmdline == "" {
-		status.Cmdline = strings.Join(status.Args, " ")
+		// Generate `status.Cmdline` here for compatibility because on Windows
+		// `status.Args` is set by `FillMetricsRequiringMoreAccess`.
+		if len(status.Args) > 0 && status.Cmdline == "" {
+			status.Cmdline = strings.Join(status.Args, " ")
+		}
 	}
 
 	// network data

--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -291,7 +291,7 @@ func (procStats *Stats) pidFill(pid int, filter bool) (ProcState, bool, error) {
 
 	} // end cgroups processor
 
-	if _, ok := procStats.excludedPIDs[uint64(pid)]; !ok {
+	if _, isExcluded := procStats.excludedPIDs[uint64(pid)]; !isExcluded {
 		status, err = FillMetricsRequiringMoreAccess(pid, status)
 		if err != nil {
 			procStats.logger.Debugf("error calling FillMetricsRequiringMoreAccess for pid %d: %w", pid, err)

--- a/metric/system/process/process_common.go
+++ b/metric/system/process/process_common.go
@@ -108,6 +108,7 @@ type Stats struct {
 	cgroups      *cgroup.Reader
 	logger       *logp.Logger
 	host         types.Host
+	excludedPIDs map[uint64]struct{} // List of PIDs to ignore while calling FillMetricsRequiringMoreAccess
 }
 
 // PidState are the constants for various PID states
@@ -207,6 +208,7 @@ func (procStats *Stats) Init() error {
 		}
 		procStats.cgroups = cgReader
 	}
+	procStats.excludedPIDs = processesToIgnore()
 	return nil
 }
 

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -642,7 +642,7 @@ func TestProcessesExcluded(t *testing.T) {
 	require.NoError(t, state.Init())
 
 	_, processes, err := state.Get()
-	require.NoError(t, err)
+	assert.True(t, isNonFatal(err), fmt.Sprintf("Fatal Error: %s", err))
 
 	for _, pMap := range processes {
 		iPid, err := pMap.GetValue("process.pid")

--- a/metric/system/process/process_windows.go
+++ b/metric/system/process/process_windows.go
@@ -27,7 +27,9 @@ import (
 	"unsafe"
 
 	xsyswindows "golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
 
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/opt"
 	"github.com/elastic/elastic-agent-system-metrics/metric/system/resolve"
 	gowindows "github.com/elastic/go-windows"
@@ -467,7 +469,7 @@ func fillIdleProcess(state ProcState) (ProcState, error) {
 	return state, nil
 }
 
-func shouldIgnore(pid int) (bool, err) {
+func shouldIgnore(pid int) bool {
 	// shouldIgnore checks if we should ignore the pid, to avoid elevated permissions
 
 	// LSASS.exe is a process which has no useful cmdline arguments, we should ignore acessing such process to avoid triggering Windows ASR rules

--- a/metric/system/process/process_windows.go
+++ b/metric/system/process/process_windows.go
@@ -199,6 +199,9 @@ func FillMetricsRequiringMoreAccess(pid int, state ProcState) (ProcState, error)
 }
 
 func getProcArgs(pid int) ([]string, error) {
+	if ok := shouldIgnore(pid); ok {
+		return []string{}, nil
+	}
 	handle, err := syscall.OpenProcess(
 		windows.PROCESS_QUERY_LIMITED_INFORMATION|
 			windows.PROCESS_VM_READ,
@@ -462,4 +465,26 @@ func fillIdleProcess(state ProcState) (ProcState, error) {
 	state.CPU.Total.Ticks = opt.UintWith(uint64(idle / 1e6))
 	state.CPU.Total.Value = opt.FloatWith(idle)
 	return state, nil
+}
+
+func shouldIgnore(pid int) (bool, err) {
+	// shouldIgnore checks if we should ignore the pid, to avoid elevated permissions
+
+	// LSASS.exe is a process which has no useful cmdline arguments, we should ignore acessing such process to avoid triggering Windows ASR rules
+	// we can query pid for LASASS.exe from registry
+
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, "SYSTEM\\CurrentControlSet\\Control\\Lsa", registry.READ)
+	if err != nil {
+		logp.L().Warnw("Failed to read registry path SYSTEM\\CurrentControlSet\\Control\\Lsa", "error", err)
+		return false
+	}
+	lsassPid, _, err := key.GetIntegerValue("LasPid")
+	if err != nil {
+		logp.L().Warnw("Failed to read pid for lsass.exe", "error", err)
+		return false
+	}
+	if lsassPid == pid {
+		return true
+	}
+	return false
 }

--- a/metric/system/process/process_windows.go
+++ b/metric/system/process/process_windows.go
@@ -202,7 +202,7 @@ func FillMetricsRequiringMoreAccess(pid int, state ProcState) (ProcState, error)
 
 func getProcArgs(pid int) ([]string, error) {
 	if ok := shouldIgnore(pid); ok {
-		return []string{}, nil
+		return nil, nil
 	}
 	handle, err := syscall.OpenProcess(
 		windows.PROCESS_QUERY_LIMITED_INFORMATION|
@@ -480,6 +480,7 @@ func shouldIgnore(pid int) bool {
 		logp.L().Warnw("Failed to read registry path SYSTEM\\CurrentControlSet\\Control\\Lsa", "error", err)
 		return false
 	}
+	defer key.Close()
 	lsassPid, _, err := key.GetIntegerValue("LasPid")
 	if err != nil {
 		logp.L().Warnw("Failed to read pid for lsass.exe", "error", err)

--- a/metric/system/process/process_windows_test.go
+++ b/metric/system/process/process_windows_test.go
@@ -69,3 +69,16 @@ func TestGetInfoForPid_numThreads(t *testing.T) {
 			numThreads, want, expected)
 	}
 }
+
+func TestLsassFound(t *testing.T) {
+	processNames := []string{"lsass.exe"}
+	m := processesToIgnore()
+	require.NotEmpty(t, m)
+
+	for pid := range m {
+		state, err := GetInfoForPid(resolve.NewTestResolver("/"), int(pid))
+		if err == nil {
+			require.Contains(t, processNames, state.Name)
+		}
+	}
+}


### PR DESCRIPTION
See https://github.com/elastic/beats/issues/41407 for more details.

TL;DR;

Processes such as `lsass.exe` has no meaningful cmd line and and can trigger false positives with Windows ASR rules.
We can find pid for that using `SYSTEM\\CurrentControlSet\\Control\\Lsa` path

Relates https://github.com/elastic/beats/issues/41407