### PR TITLE
[process] - Add a boolean to detect partial matches

### DIFF
--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -140,11 +140,11 @@ func (procStats *Stats) Get() ([]mapstr.M, []mapstr.M, error) {
 		procs = append(procs, proc)
 		rootEvents = append(rootEvents, rootMap)
 	}
-	if len(failedPIDs) > 0 {
+	if wrappedErr != nil && len(failedPIDs) > 0 {
 		procStats.logger.Debugf("error fetching process metrics: %v", wrappedErr)
 		return procs, rootEvents, NonFatalErr{Err: fmt.Errorf(errFetchingPIDs, len(failedPIDs))}
 	}
-	return procs, rootEvents, nil
+	return procs, rootEvents, toNonFatal(wrappedErr)
 }
 
 // GetOne fetches process data for a given PID if its name matches the regexes provided from the host.

--- a/metric/system/process/process_types.go
+++ b/metric/system/process/process_types.go
@@ -57,8 +57,10 @@ type ProcState struct {
 	// meta
 	SampleTime time.Time `struct:"-,omitempty"`
 
-	// boolean to indicate that given PID has failed due to some error.
+	// boolean to indicate that given PID has completeley failed due to some error.
 	Failed bool `struct:"-,omitempty"`
+	// boolean to indicate that given state is partially filled.
+	Partial bool `struct:"-,omitempty"`
 }
 
 // ProcCPUInfo is the main struct for CPU metrics


### PR DESCRIPTION
This PR follows up on https://github.com/elastic/elastic-agent-system-metrics/pull/195 and adds a new boolean to indicate if a given process state is partial. 
This is useful while returning errors to the caller.