### PR TITLE
Bug: Fix error formatting

### DIFF
--- a/metric/cpu/metrics_freebsd.go
+++ b/metric/cpu/metrics_freebsd.go
@@ -42,7 +42,7 @@ func parseCPULine(line string) (CPU, error) {
 	tryParseUint := func(name, field string) (v opt.Uint) {
 		u, err := touint(field)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to parse %v: %s", name, field))
+			errs = append(errs, fmt.Errorf("failed to parse %s: %s", name, field))
 		} else {
 			v = opt.UintWith(u)
 		}

--- a/metric/memory/memory_aix.go
+++ b/metric/memory/memory_aix.go
@@ -57,7 +57,7 @@ func get(_ resolve.Resolver) (Memory, error) {
 	meminfo := C.perfstat_memory_total_t{}
 	_, err := C.perfstat_memory_total(nil, &meminfo, C.sizeof_perfstat_memory_total_t, 1)
 	if err != nil {
-		return memData, fmt.Errorf("perfstat_memory_total: %s", err)
+		return memData, fmt.Errorf("perfstat_memory_total: %w", err)
 	}
 
 	totalMem := uint64(meminfo.real_total) * system.pagesize

--- a/metric/system/cgroup/util_test.go
+++ b/metric/system/cgroup/util_test.go
@@ -123,7 +123,7 @@ func TestSupportedSubsystems(t *testing.T) {
 func TestSupportedSubsystemsErrCgroupsMissing(t *testing.T) {
 	_, err := SupportedSubsystems(resolve.NewTestResolver("testdata/doesnotexist"))
 	if !errors.Is(err, ErrCgroupsMissing) {
-		t.Fatalf("expected ErrCgroupsMissing, but got %v", err)
+		t.Fatalf("expected ErrCgroupsMissing, but got %s", err)
 	}
 }
 

--- a/metric/system/diskio/diskstat_windows_helper.go
+++ b/metric/system/diskio/diskstat_windows_helper.go
@@ -72,7 +72,7 @@ func ioCounters(names ...string) (map[string]disk.IOCountersStat, error) {
 		var counter diskPerformance
 		err = ioCounter(drive.UNCPath, &counter)
 		if err != nil {
-			logp.Err("Could not return any performance counter values for %s .Error: %v", drive.UNCPath, err)
+			logp.Err("Could not return any performance counter values for %s .Error: %s", drive.UNCPath, err)
 			continue
 		}
 		ret[drive.Name] = disk.IOCountersStat{

--- a/metric/system/filesystem/filesystem_test.go
+++ b/metric/system/filesystem/filesystem_test.go
@@ -44,7 +44,7 @@ func TestFileSystemList(t *testing.T) {
 
 	for _, fs := range fss {
 		err := fs.GetUsage()
-		assert.NoError(t, err, "filesystem=%#v: %v", fs, err)
+		assert.NoError(t, err, "filesystem=%#v: %s", fs, err)
 
 	}
 }

--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -62,7 +62,7 @@ func ListStates(hostfs resolve.Resolver) ([]ProcState, error) {
 	}
 	failedPIDs := extractFailedPIDs(pidMap)
 	if err != nil && len(failedPIDs) > 0 {
-		init.logger.Debugf("error fetching process metrics: %v", err)
+		init.logger.Debugf("error fetching process metrics: %s", err)
 		return plist, NonFatalErr{Err: fmt.Errorf(errFetchingPIDs, len(failedPIDs))}
 	}
 	return plist, toNonFatal(err)
@@ -115,7 +115,7 @@ func (procStats *Stats) Get() ([]mapstr.M, []mapstr.M, error) {
 	if procStats.host != nil {
 		memStats, err := procStats.host.Memory()
 		if err != nil {
-			procStats.logger.Warnf("Getting memory details: %v", err)
+			procStats.logger.Warnf("Getting memory details: %s", err)
 		} else {
 			totalPhyMem = memStats.Total
 		}
@@ -141,7 +141,7 @@ func (procStats *Stats) Get() ([]mapstr.M, []mapstr.M, error) {
 		rootEvents = append(rootEvents, rootMap)
 	}
 	if wrappedErr != nil && len(failedPIDs) > 0 {
-		procStats.logger.Debugf("error fetching process metrics: %v", wrappedErr)
+		procStats.logger.Debugf("error fetching process metrics: %s", wrappedErr)
 		return procs, rootEvents, NonFatalErr{Err: fmt.Errorf(errFetchingPIDs, len(failedPIDs))}
 	}
 	return procs, rootEvents, toNonFatal(wrappedErr)

--- a/metric/system/process/process_common.go
+++ b/metric/system/process/process_common.go
@@ -162,7 +162,7 @@ func (procStats *Stats) Init() error {
 	procStats.host, err = sysinfo.Host()
 	if err != nil {
 		procStats.host = nil
-		procStats.logger.Warnf("Getting host details: %v", err)
+		procStats.logger.Warnf("Getting host details: %s", err)
 	}
 
 	// footcannon prevention
@@ -201,7 +201,7 @@ func (procStats *Stats) Init() error {
 	if procStats.EnableCgroups {
 		cgReader, err := cgroup.NewReaderOptions(procStats.CgroupOpts)
 		if errors.Is(err, cgroup.ErrCgroupsMissing) {
-			logp.Warn("cgroup data collection will be disabled: %v", err)
+			logp.Warn("cgroup data collection will be disabled: %s", err)
 			procStats.EnableCgroups = false
 		} else if err != nil {
 			return fmt.Errorf("error initializing cgroup reader: %w", err)

--- a/metric/system/process/process_linux_darwin_test.go
+++ b/metric/system/process/process_linux_darwin_test.go
@@ -40,7 +40,7 @@ func TestGetInfoForPid_numThreads(t *testing.T) {
 	if !got.NumThreads.Exists() {
 		bs, err := json.Marshal(got)
 		if err != nil {
-			t.Logf("could not marshal ProcState: %v", err)
+			t.Logf("could not marshal ProcState: %s", err)
 		}
 		t.Fatalf("num_thread was not collected. Collected info: %s", bs)
 	}

--- a/metric/system/process/process_test.go
+++ b/metric/system/process/process_test.go
@@ -115,7 +115,7 @@ func TestGetState(t *testing.T) {
 
 	assert.Eventuallyf(t, test,
 		time.Second*5, 50*time.Millisecond,
-		"got process state %q. Last error: %v", got, err)
+		"got process state %q. Last error: %s", got, err)
 }
 
 func TestGetOneRoot(t *testing.T) {

--- a/metric/system/process/process_windows_test.go
+++ b/metric/system/process/process_windows_test.go
@@ -54,7 +54,7 @@ func TestGetInfoForPid_numThreads(t *testing.T) {
 	if !state.NumThreads.Exists() {
 		bs, err := json.Marshal(state)
 		if err != nil {
-			t.Logf("could not marshal ProcState: %v", err)
+			t.Logf("could not marshal ProcState: %s", err)
 		}
 		t.Fatalf("num_thread was not collected. Collected info: %s", bs)
 	}

--- a/report/metrics_file_descriptors.go
+++ b/report/metrics_file_descriptors.go
@@ -37,7 +37,7 @@ func FDUsageReporter(logger *logp.Logger, processStats *process.Stats) func(_ mo
 
 		open, hardLimit, softLimit, err := getFDUsage(processStats)
 		if err != nil {
-			logger.Error("Error while retrieving FD information: %v", err)
+			logger.Errorf("Error while retrieving FD information: %s", err)
 			return
 		}
 

--- a/report/metrics_handles.go
+++ b/report/metrics_handles.go
@@ -38,7 +38,7 @@ var (
 func SetupWindowsHandlesMetrics(logger *logp.Logger, reg *monitoring.Registry) {
 	beatProcessSysInfo, err := sysinfo.Self()
 	if err != nil {
-		logger.Error("Error while getting own process info: %v", err)
+		logger.Errorf("Error while getting own process info: %s", err)
 		logger.Error(fileHandlesNotReported)
 		return
 	}
@@ -46,7 +46,7 @@ func SetupWindowsHandlesMetrics(logger *logp.Logger, reg *monitoring.Registry) {
 	var ok bool
 	handleCounter, ok = beatProcessSysInfo.(types.OpenHandleCounter)
 	if !ok {
-		logger.Error("Process does not implement types.OpenHandleCounter: %v", beatProcessSysInfo)
+		logger.Errorf("Process does not implement types.OpenHandleCounter: %s", beatProcessSysInfo)
 		logger.Error(fileHandlesNotReported)
 		return
 	}
@@ -61,7 +61,7 @@ func openHandlesReporter(logger *logp.Logger) func(_ monitoring.Mode, V monitori
 
 		n, err := handleCounter.OpenHandleCount()
 		if err != nil {
-			logger.Error("Error while retrieving the number of open file handles: %v", err)
+			logger.Errorf("Error while retrieving the number of open file handles: %s", err)
 			return
 		}
 		monitoring.ReportInt(V, "open", int64(n))

--- a/report/report.go
+++ b/report/report.go
@@ -51,7 +51,7 @@ func MemStatsReporter(logger *logp.Logger, processStats *process.Stats) func(mon
 
 		state, err := processStats.GetSelf()
 		if err != nil {
-			logger.Errorf("Error while getting memory usage: %v", err)
+			logger.Errorf("Error while getting memory usage: %s", err)
 			return
 		}
 
@@ -67,7 +67,7 @@ func InstanceCPUReporter(logger *logp.Logger, processStats *process.Stats) func(
 
 		state, err := processStats.GetSelf()
 		if err != nil {
-			logger.Errorf("Error retrieving CPU percentages: %v", err)
+			logger.Errorf("Error retrieving CPU percentages: %s", err)
 			return
 		}
 
@@ -99,7 +99,7 @@ func ReportSystemLoadAverage(_ monitoring.Mode, V monitoring.Visitor) {
 
 	load, err := cpu.Load()
 	if err != nil {
-		logp.Err("Error retrieving load average: %v", err)
+		logp.Err("Error retrieving load average: %s", err)
 		return
 	}
 	avgs := load.Averages()
@@ -145,16 +145,16 @@ func InstanceCroupsReporter(logger *logp.Logger, override string) func(monitorin
 		})
 		if err != nil {
 			if errors.Is(err, cgroup.ErrCgroupsMissing) {
-				logger.Warnf("cgroup data collection disabled in internal monitoring: %v", err)
+				logger.Warnf("cgroup data collection disabled in internal monitoring: %s", err)
 			} else {
-				logger.Errorf("cgroup data collection disabled in internal monitoring: %v", err)
+				logger.Errorf("cgroup data collection disabled in internal monitoring: %s", err)
 			}
 			return
 		}
 
 		cgv, err := cgroups.CgroupsVersion(pid)
 		if err != nil {
-			logger.Errorf("error determining cgroups version for internal monitoring: %v", err)
+			logger.Errorf("error determining cgroups version for internal monitoring: %s", err)
 			return
 		}
 
@@ -170,7 +170,7 @@ func InstanceCroupsReporter(logger *logp.Logger, override string) func(monitorin
 func ReportMetricsCGV1(logger *logp.Logger, pid int, cgroups *cgroup.Reader, V monitoring.Visitor) {
 	selfStats, err := cgroups.GetV1StatsForProcess(pid)
 	if err != nil {
-		logger.Errorf("error getting cgroup stats for V1: %v", err)
+		logger.Errorf("error getting cgroup stats for V1: %s", err)
 	}
 	// GetStatsForProcess returns a nil selfStats and no error when there's no stats
 	if selfStats == nil {
@@ -231,7 +231,7 @@ func ReportMetricsCGV1(logger *logp.Logger, pid int, cgroups *cgroup.Reader, V m
 func ReportMetricsCGV2(logger *logp.Logger, pid int, cgroups *cgroup.Reader, V monitoring.Visitor) {
 	selfStats, err := cgroups.GetV2StatsForProcess(pid)
 	if err != nil {
-		logger.Errorf("error getting cgroup stats for V2: %v", err)
+		logger.Errorf("error getting cgroup stats for V2: %s", err)
 		return
 	}
 


### PR DESCRIPTION
## What does this PR do?

Fix error formatting.

## Why is it important?

To avoid funky error reporting such as:
```
2025-03-12T16:38:11.740Z ERROR [metrics] map[file.line:40 file.name:report/metrics_file_descriptors.go function:github.com/elastic/elastic-agent-system-metrics/report.SetupLinuxBSDFDMetrics.FDUsageReporter.func1] Error while retrieving FD information: %verror fetching PID 38644: GetInfoForPid: no such process {"ecs.version": "1.6.0"}
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

