### PR TITLE
[registry] use per-namespace registry for platform specific metrics

### DIFF
--- a/report/setup.go
+++ b/report/setup.go
@@ -94,7 +94,7 @@ func SetupMetrics(logger *logp.Logger, name, version string, opts ...OptionFunc)
 	monitoring.NewFunc(opt.processMetrics, "runtime", ReportRuntime, monitoring.Report)
 	monitoring.NewFunc(opt.processMetrics, "info", infoReporter(name, version), monitoring.Report)
 
-	setupPlatformSpecificMetrics(logger, processStats, systemMetrics, processMetrics)
+	setupPlatformSpecificMetrics(logger, processStats, opt.systemMetrics, opt.processMetrics)
 
 	return nil
 }


### PR DESCRIPTION
Use per-namespace registry for platform specific metrics as well.

For some reason, I missed this in https://github.com/elastic/elastic-agent-system-metrics/pull/205 and it wasn't get caught  during reviews as well.