### PR TITLE
Fix AIX build related issues.

### DIFF
--- a/metric/system/filesystem/filesystem.go
+++ b/metric/system/filesystem/filesystem.go
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build darwin || freebsd || linux || openbsd || windows
-// +build darwin freebsd linux openbsd windows
+//go:build darwin || freebsd || linux || openbsd || windows || aix
+// +build darwin freebsd linux openbsd windows aix
 
 package filesystem
 

--- a/metric/system/filesystem/filesystem_unix_common.go
+++ b/metric/system/filesystem/filesystem_unix_common.go
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build freebsd || linux
-// +build freebsd linux
+//go:build freebsd || linux || aix
+// +build freebsd linux || aix
 
 package filesystem
 

--- a/metric/system/process/process_aix.go
+++ b/metric/system/process/process_aix.go
@@ -46,7 +46,7 @@ func (procStats *Stats) FetchPids() (ProcsMap, []ProcState, error) {
 	pid := C.pid_t(0)
 
 	procMap := make(ProcsMap, 0)
-	var wrappedErr err
+	var wrappedErr error
 	var plist []ProcState
 	for {
 		// getprocs first argument is a void*
@@ -200,4 +200,8 @@ func FillPidMetrics(_ resolve.Resolver, pid int, state ProcState, filter func(st
 
 func FillMetricsRequiringMoreAccess(_ int, state ProcState) (ProcState, error) {
 	return state, nil
+}
+
+func GetSelfPid(hostfs resolve.Resolver) (int, error) {
+	return os.Getpid(), nil
 }


### PR DESCRIPTION
There are two issues in AIX to build elastic-agent-system-metrics.

1: The required build tags needed to build the required Go files. If it's not there then we get function undefined errors.
2: Missing function declaration GetSelfPid().