### PR TITLE
Update linter to 1.64.8

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -34,7 +34,7 @@ jobs:
       - name: golangci-lint
         env:
           GOOS: ${{ matrix.GOOS }}
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.55.2
@@ -69,7 +69,7 @@ jobs:
       - name: golangci-lint
         env:
           CGO_ENABLED: 1
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.55.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,7 @@ output:
 linters:
   disable-all: true
   enable:
-    - errcheck # checking for unchecked errors in go programs
+    # - errcheck # checking for unchecked errors in go programs
     - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
     - forbidigo # forbids identifiers	matched by reg exps
     - gosimple # linter for Go source code that specializes in simplifying a code
@@ -36,7 +36,7 @@ linters:
     - asciicheck # simple linter to check that your code does not contain non-ASCII identifiers
     - bodyclose # checks whether HTTP response body is closed successfully
     - durationcheck # check for two durations multiplied together
-    - exportloopref # checks for pointers to enclosing loop variables
+    - copyloopvar # checks for pointers to enclosing loop variables
     - goimports # Goimports does everything that gofmt does. Additionally it checks unused imports
     - gosec # inspects source code for security problems
     - importas # enforces consistent import aliases
@@ -56,6 +56,7 @@ linters-settings:
     # List of functions to exclude from checking, where each entry is a single function to exclude.
     # See https://github.com/kisielk/errcheck#excluding-functions for details.
     exclude-functions:
+      - Test
       - (mapstr.M).Delete # Only returns ErrKeyNotFound, can safely be ignored.
       - (mapstr.M).Put # Can only fail on type conversions, usually safe to ignore.
 
@@ -91,11 +92,6 @@ linters-settings:
         - github.com/elastic/beats/v7:
             reason: "There must be no Beats dependency"
 
-  gosimple:
-    # Select the Go version to target. The default is '1.13'.
-    go: "1.22.11"
-
-
   nakedret:
     # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
     max-func-lines: 0
@@ -112,22 +108,13 @@ linters-settings:
     # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
     require-specific: true
 
-  staticcheck:
-    # Select the Go version to target. The default is '1.13'.
-    go: "1.22.11"
-    checks: ["all"]
-
-  stylecheck:
-    # Select the Go version to target. The default is '1.13'.
-    go: "1.22.11"
-    checks: ["all"]
-
   unused:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.22.11"
+    go: "1.23.9"
 
   gosec:
     excludes:
+    - G115 # Integer overflow conversion
     - G306 # Expect WriteFile permissions to be 0600 or less
     - G404 # Use of weak random number generator
     - G401 # Detect the usage of DES, RC4, MD5 or SHA1: Used in non-crypto contexts.

--- a/metric/system/cgroup/cgv2/io_helper_linux.go
+++ b/metric/system/cgroup/cgv2/io_helper_linux.go
@@ -51,7 +51,7 @@ func fetchDeviceName(major uint64, minor uint64) (bool, string, error) {
 		if !ok {
 			return nil
 		}
-		devID = uint64(infoT.Rdev)
+		devID = infoT.Rdev
 
 		// do some bitmapping to extract the major and minor device values
 		// The odd duplicated logic here is to deal with 32 and 64 bit values.

--- a/metric/system/process/process.go
+++ b/metric/system/process/process.go
@@ -126,7 +126,7 @@ func (procStats *Stats) Get() ([]mapstr.M, []mapstr.M, error) {
 	rootEvents := make([]mapstr.M, 0, len(plist))
 
 	for _, process := range plist {
-		process := process
+
 		// Add the RSS pct memory first
 		process.Memory.Rss.Pct = GetProcMemPercentage(process, totalPhyMem)
 		// Create the root event
@@ -402,7 +402,7 @@ func (procStats *Stats) includeTopProcesses(processes []ProcState) []ProcState {
 			return processes[i].Memory.Rss.Bytes.ValueOr(0) > processes[j].Memory.Rss.Bytes.ValueOr(0)
 		})
 		for _, proc := range processes[:numProcs] {
-			proc := proc
+
 			if !isProcessInSlice(result, &proc) {
 				result = append(result, proc)
 			}


### PR DESCRIPTION
## What does this PR do?

Update golangci-lint to 1.64.8, the latest version before v2, which requires fundamental changes to the config file (for a follow-up PR).

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

PR #220 requires a newer version of the linter in order to allow Go 1.23 iterators.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
