### PR TITLE
test: bind GOMODCACHE to containers in docker tests

### DIFF
--- a/dev-tools/systemtests/container.go
+++ b/dev-tools/systemtests/container.go
@@ -257,6 +257,7 @@ func (tr *DockerTestRunner) createTestContainer(ctx context.Context, apiClient *
 	}, &container.HostConfig{
 		CgroupnsMode: tr.CgroupNSMode,
 		Privileged:   tr.Privileged,
+		Binds:        []string{fmt.Sprintf("/:%s", mountPath), fmt.Sprintf("%s:/app", cwd)},
 		Mounts: []mount.Mount{
 			{
 				Type:   mount.TypeBind,
@@ -264,7 +265,6 @@ func (tr *DockerTestRunner) createTestContainer(ctx context.Context, apiClient *
 				Target: "/go/pkg/mod",
 			},
 		},
-		Binds: []string{fmt.Sprintf("/:%s", mountPath), fmt.Sprintf("%s:/app", cwd)},
 	}, nil, nil, "")
 	require.NoError(tr.Runner, err, "error creating container")
 


### PR DESCRIPTION
## What does this PR do?

bind GOMODCACHE to containers in docker tests

## Why is it important?

avoid redownloading dependency on each docker run

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

