### PR TITLE
feat: require passing registries for metrics setup

### DIFF
--- a/report/metrics_common.go
+++ b/report/metrics_common.go
@@ -30,14 +30,12 @@ import (
 )
 
 var (
-	ephemeralID    uuid.UUID
-	processMetrics *monitoring.Registry
-	startTime      time.Time
+	ephemeralID uuid.UUID
+	startTime   time.Time
 )
 
 func init() {
 	startTime = time.Now()
-	processMetrics = monitoring.Default.NewRegistry("beat")
 
 	var err error
 	ephemeralID, err = uuid.NewV4()

--- a/report/metrics_report_test.go
+++ b/report/metrics_report_test.go
@@ -30,7 +30,9 @@ import (
 )
 
 func TestSystemMetricsReport(t *testing.T) {
-	err := SetupMetrics(logptest.NewTestingLogger(t, ""), "TestSys", "test")
+	systemMetrics := monitoring.NewRegistry()
+	processMetrics := monitoring.NewRegistry()
+	err := SetupMetrics(logptest.NewTestingLogger(t, ""), "TestSys", "test", systemMetrics, processMetrics)
 	require.NoError(t, err)
 
 	var gotCPU, gotMem, gotInfo atomic.Bool

--- a/report/setup.go
+++ b/report/setup.go
@@ -31,33 +31,8 @@ import (
 )
 
 var (
-	systemMetrics *monitoring.Registry
-
 	processStats *process.Stats
 )
-
-func init() {
-	systemMetrics = monitoring.Default.NewRegistry("system")
-}
-
-type option struct {
-	systemMetrics  *monitoring.Registry
-	processMetrics *monitoring.Registry
-}
-
-type OptionFunc func(o *option)
-
-func WithProcessRegistry(r *monitoring.Registry) OptionFunc {
-	return func(o *option) {
-		o.processMetrics = r
-	}
-}
-
-func WithSystemRegistry(r *monitoring.Registry) OptionFunc {
-	return func(o *option) {
-		o.systemMetrics = r
-	}
-}
 
 // monitoringCgroupsHierarchyOverride is an undocumented environment variable which
 // overrides the cgroups path under /sys/fs/cgroup, which should be set to "/" when running
@@ -65,15 +40,8 @@ func WithSystemRegistry(r *monitoring.Registry) OptionFunc {
 const monitoringCgroupsHierarchyOverride = "LIBBEAT_MONITORING_CGROUPS_HIERARCHY_OVERRIDE"
 
 // SetupMetrics creates a basic suite of metrics handlers for monitoring, including build info and system resources
-func SetupMetrics(logger *logp.Logger, name, version string, opts ...OptionFunc) error {
-	opt := &option{
-		systemMetrics:  systemMetrics,
-		processMetrics: processMetrics,
-	}
-	for _, o := range opts {
-		o(opt)
-	}
-	monitoring.NewFunc(opt.systemMetrics, "cpu", ReportSystemCPUUsage, monitoring.Report)
+func SetupMetrics(logger *logp.Logger, name, version string, systemMetrics *monitoring.Registry, processMetrics *monitoring.Registry) error {
+	monitoring.NewFunc(systemMetrics, "cpu", ReportSystemCPUUsage, monitoring.Report)
 
 	name = processName(name)
 	processStats = &process.Stats{
@@ -89,12 +57,12 @@ func SetupMetrics(logger *logp.Logger, name, version string, opts ...OptionFunc)
 		return fmt.Errorf("failed to init process stats for agent: %w", err)
 	}
 
-	monitoring.NewFunc(opt.processMetrics, "memstats", MemStatsReporter(logger, processStats), monitoring.Report)
-	monitoring.NewFunc(opt.processMetrics, "cpu", InstanceCPUReporter(logger, processStats), monitoring.Report)
-	monitoring.NewFunc(opt.processMetrics, "runtime", ReportRuntime, monitoring.Report)
-	monitoring.NewFunc(opt.processMetrics, "info", infoReporter(name, version), monitoring.Report)
+	monitoring.NewFunc(processMetrics, "memstats", MemStatsReporter(logger, processStats), monitoring.Report)
+	monitoring.NewFunc(processMetrics, "cpu", InstanceCPUReporter(logger, processStats), monitoring.Report)
+	monitoring.NewFunc(processMetrics, "runtime", ReportRuntime, monitoring.Report)
+	monitoring.NewFunc(processMetrics, "info", infoReporter(name, version), monitoring.Report)
 
-	setupPlatformSpecificMetrics(logger, processStats, opt.systemMetrics, opt.processMetrics)
+	setupPlatformSpecificMetrics(logger, processStats, systemMetrics, processMetrics)
 
 	return nil
 }

--- a/report/setup_other.go
+++ b/report/setup_other.go
@@ -23,9 +23,12 @@
 
 package report
 
-import "github.com/elastic/elastic-agent-libs/logp"
+import (
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
 
-func SetupMetrics(logger *logp.Logger, name, version string) error {
+func SetupMetrics(logger *logp.Logger, name, version string, systemMetrics *monitoring.Registry, processMetrics *monitoring.Registry) error {
 	logp.Warn("Metrics not implemented for this OS.")
 	return nil
 }


### PR DESCRIPTION
## What does this PR do?

remove global registry usage and require explicitly passing system and process registry
also fix compile errors for other oses

## Why is it important?

move away from global registries similar to what has been recently done in beats

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

