### PR TITLE
fix: resolve index out of bounds in diskio stat

### DIFF
--- a/metric/cpu/metrics_darwin.go
+++ b/metric/cpu/metrics_darwin.go
@@ -44,7 +44,11 @@ func Get(m *Monitor) (CPUMetrics, error) {
 	for _, cpu := range perCPU {
 		cpulist = append(cpulist, fillCPU(cpu))
 	}
-	return CPUMetrics{totals: fillCPU(sum[0]), list: cpulist}, nil
+	cpuTotal := CPU{}
+	if len(sum) > 0 {
+		cpuTotal = fillCPU(sum[0])
+	}
+	return CPUMetrics{totals: cpuTotal, list: cpulist}, nil
 }
 
 func fillCPU(raw cpu.TimesStat) CPU {

--- a/metric/system/diskio/diskstat_linux.go
+++ b/metric/system/diskio/diskstat_linux.go
@@ -57,7 +57,9 @@ func (stat *IOStat) OpenSampling() error {
 	if err != nil {
 		return err
 	}
-	stat.curCPU = times[0]
+	if len(times) > 0 {
+		stat.curCPU = times[0]
+	}
 	return nil
 }
 


### PR DESCRIPTION
## What does this PR do?

it's possible on linux to get an empty slice if the file is empty

protect against that by checking the slice len.

It's impossible on darwin but let's not rely on implementation details and also check there.

## Why is it important?

prevent index out of bounds error

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

