### PR TITLE
[cgv2] io: Use omitempty for Pressure

### DIFF
--- a/metric/system/cgroup/cgv2/io.go
+++ b/metric/system/cgroup/cgv2/io.go
@@ -36,7 +36,7 @@ type IOSubsystem struct {
 	Path string `json:"path,omitempty"` // Path to the cgroup relative to the cgroup subsystem's mountpoint.
 
 	Stats    map[string]IOStat            `json:"stats" struct:"stats"`
-	Pressure map[string]cgcommon.Pressure `json:"pressure" struct:"pressure"`
+	Pressure map[string]cgcommon.Pressure `json:"pressure,omitempty" struct:"pressure,omitempty"`
 }
 
 // IOStat carries io.Stat data for the controllers


### PR DESCRIPTION
## What does this PR do?
Consistent with memory and cpu pressure stats

Relevant when pressure stats are disabled e.g. with
```sh
echo 0 | sudo tee /sys/fs/cgroup/<some cgroup>/cgroup.pressure
```

## Why is it important?

To consistently format metricbeat output

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`