### PR TITLE
[cgv2] Convert cpu.stat microseconds to nanoseconds at parse site

### DIFF
--- a/metric/system/cgroup/cgv2/cpu.go
+++ b/metric/system/cgroup/cgv2/cpu.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/elastic/elastic-agent-libs/opt"
 	"github.com/elastic/elastic-agent-system-metrics/metric/system/cgroup/cgcommon"
@@ -131,12 +132,14 @@ func getStats(path string) (CPUStats, error) {
 			return data, fmt.Errorf("error parsing cpu.stat file: %w", err)
 		}
 		switch key {
+		// cpu.stat reports CPU time in microseconds; the destination *.NS
+		// fields are nanoseconds (matching cgroups v1), so scale at parse.
 		case "usage_usec":
-			data.Usage.NS = val
+			data.Usage.NS = val * uint64(time.Microsecond)
 		case "user_usec":
-			data.User.NS = val
+			data.User.NS = val * uint64(time.Microsecond)
 		case "system_usec":
-			data.System.NS = val
+			data.System.NS = val * uint64(time.Microsecond)
 		case "nr_periods":
 			data.Periods = opt.UintWith(val)
 		case "nr_throttled":

--- a/metric/system/cgroup/cgv2/v2_test.go
+++ b/metric/system/cgroup/cgv2/v2_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -285,13 +286,13 @@ func TestGetCPU(t *testing.T) {
 				},
 				Stats: CPUStats{
 					Usage: cgcommon.CPUUsage{
-						NS: 26772130245,
+						NS: 26772130245 * uint64(time.Microsecond),
 					},
 					User: cgcommon.CPUUsage{
-						NS: 20979069928,
+						NS: 20979069928 * uint64(time.Microsecond),
 					},
 					System: cgcommon.CPUUsage{
-						NS: 5793060316,
+						NS: 5793060316 * uint64(time.Microsecond),
 					},
 					Periods: opt.UintWith(1),
 					Throttled: ThrottledField{
@@ -336,13 +337,13 @@ func TestGetCPU(t *testing.T) {
 				Pressure: map[string]cgcommon.Pressure{},
 				Stats: CPUStats{
 					Usage: cgcommon.CPUUsage{
-						NS: 26772130245,
+						NS: 26772130245 * uint64(time.Microsecond),
 					},
 					User: cgcommon.CPUUsage{
-						NS: 20979069928,
+						NS: 20979069928 * uint64(time.Microsecond),
 					},
 					System: cgcommon.CPUUsage{
-						NS: 5793060316,
+						NS: 5793060316 * uint64(time.Microsecond),
 					},
 					Periods: opt.UintWith(1),
 					Throttled: ThrottledField{
@@ -384,6 +385,36 @@ func TestGetCPU(t *testing.T) {
 			assert.EqualValues(t, test.expected, cpu)
 		})
 	}
+}
+
+// TestGetStatsUsecToNanos pins the µs -> ns conversion contract for the
+// *_usec fields in cgroups v2 cpu.stat. throttled_usec is intentionally
+// left in microseconds (its destination field is .Us).
+func TestGetStatsUsecToNanos(t *testing.T) {
+	dir := t.TempDir()
+	const content = `usage_usec 123
+user_usec 100
+system_usec 23
+nr_periods 7
+nr_throttled 2
+throttled_usec 50
+`
+	writeFile(t, filepath.Join(dir, "cpu.stat"), content)
+
+	stats, err := getStats(dir)
+	require.NoError(t, err)
+
+	expected := CPUStats{
+		Usage:   cgcommon.CPUUsage{NS: 123 * uint64(time.Microsecond)},
+		User:    cgcommon.CPUUsage{NS: 100 * uint64(time.Microsecond)},
+		System:  cgcommon.CPUUsage{NS: 23 * uint64(time.Microsecond)},
+		Periods: opt.UintWith(7),
+		Throttled: ThrottledField{
+			Periods: opt.UintWith(2),
+			Us:      opt.UintWith(50),
+		},
+	}
+	assert.Equal(t, expected, stats)
 }
 
 func TestParseCPUMax(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

In `metric/system/cgroup/cgv2/cpu.go`, `getStats` reads `cpu.stat` which reports CPU time in microseconds (`usage_usec`, `user_usec`, `system_usec`) and previously assigned those values directly to fields named `*.NS`, with no µs -> ns conversion. The cgroups v1 reader in `cgv1/cpuacct.go` does normalize to nanoseconds (`convertJiffiesToNanos`), so v1 was already correct -- only v2 was wrong.

This PR:

- Scales `usage_usec`, `user_usec`, and `system_usec` by `uint64(time.Microsecond)` at the parse site, matching the time-based unit conversion already used in `cgv1/cpuacct.go`. `throttled_usec` is intentionally left in microseconds (its destination field is `.Us`).
- Adds `TestGetStatsUsecToNanos`, a focused regression test that pins the µs -> ns contract with small, hand-picked values.
- Updates `TestGetCPU` expectations that had encoded the bug as truth.

## Why is it important?

The v2 `cpu.stats.{usage,user,system}.ns` values were 1000x too small. Downstream, `cgstats.go:FillPercentages` divides this ``NS`` delta by a true nanosecond wallclock delta, so the derived `cpu.stats.{usage,user,system}.{pct,norm.pct}` were also off by 1000x.

`metric.Round` truncates to 4 decimal places (`DefaultDecimalPlacesCount = 4`), so for realistic workloads the buggy values rounded to literal `0.0000`:

| Real CPU load (1 core) | Real ``pct`` | Buggy ``pct`` (÷1000) | After ``Round`` (4dp) |
|---|---|---|---|
| 100% | 1.0 | 0.001 | 0.001 |
| 50% | 0.5 | 0.0005 | 0.0005 |
| 10% | 0.1 | 0.0001 | 0.0001 |
| 5% | 0.05 | 0.00005 | 0.0001 |
| 1% | 0.01 | 0.00001 | **0.0000** |

``norm.pct`` is further divided by ``cpuCount``, so on multi-core hosts almost everything below saturation lands at ``0.0000``.

## Risk

Behavior change for any consumer that compensated for the bug (e.g. multiplying the v2 ``ns`` field or ``pct`` by 1000). Worth calling out in release notes downstream.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Closes #293