### PR TITLE
Rename ingest-fp team reference to Streams

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,7 +8,7 @@ metadata:
 
 spec:
   type: library
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   lifecycle: production
 
@@ -25,7 +25,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ingest-fp
+  owner: group:Streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -50,7 +50,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: '!main'
       teams:
-        ingest-fp:
+        Streams:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,7 +8,7 @@ metadata:
 
 spec:
   type: library
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   lifecycle: production
 
@@ -25,7 +25,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -50,7 +50,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: '!main'
       teams:
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY


### PR DESCRIPTION
This catches up catalog-info.yaml to the GitHub team's actual current name — the team was renamed from `ingest-fp` to `Streams`.