### PR TITLE
[metrics/system/process] on linux prevent duplicate pids

### DIFF
--- a/metric/system/process/process_linux_common.go
+++ b/metric/system/process/process_linux_common.go
@@ -81,20 +81,24 @@ func (procStats *Stats) FetchPids() (ProcsMap, []ProcState, error) {
 		return nil, nil, fmt.Errorf("error reading directory names: %w", err)
 	}
 
+	return procStats.fetchPidsFromNames(names)
+}
+
+func (procStats *Stats) fetchPidsFromNames(names []string) (ProcsMap, []ProcState, error) {
 	procMap := make(ProcsMap, len(names))
 	plist := make([]ProcState, 0, len(names))
 	var wrappedErr error
 
-	// Iterate over the directory, fetch just enough info so we can filter based on user input.
 	for _, name := range names {
-
 		if !dirIsPid(name) {
 			continue
 		}
-		// Will this actually fail?
 		pid, err := strconv.Atoi(name)
 		if err != nil {
 			procStats.Logger.Debugf("Error converting PID name %s", name)
+			continue
+		}
+		if _, seen := procMap[pid]; seen {
 			continue
 		}
 		procMap, plist, err = procStats.pidIter(pid, procMap, plist)

--- a/metric/system/process/process_linux_common_test.go
+++ b/metric/system/process/process_linux_common_test.go
@@ -1,0 +1,49 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build linux
+
+package process
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFetchPidsDeduplicates verifies that fetchPidsFromNames skips a PID it has
+// already processed
+func TestFetchPidsDeduplicates(t *testing.T) {
+	stat, err := initTestResolver(t)
+	require.NoError(t, err)
+
+	pid := os.Getpid()
+	pidStr := strconv.Itoa(pid)
+
+	// Simulate Readdirnames returning the same PID twice.
+	names := []string{pidStr, pidStr}
+
+	procMap, plist, err := stat.fetchPidsFromNames(names)
+	require.NoError(t, err)
+
+	assert.Len(t, procMap, 1, "procMap should have exactly one entry for the duplicated PID")
+	assert.Len(t, plist, 1, "plist should have exactly one entry for the duplicated PID")
+	assert.Contains(t, procMap, pid)
+}


### PR DESCRIPTION
## What does this PR do?

os.File.Readdirnames is documented to make successive OS-level syscalls and, under certain circumstances, can return the same directory entry name more than once. In FetchPids, this would cause pidIter to be called twice for the same PID, producing duplicate entries in plist.

To make the guard testable, the inner loop is extracted into a private helper fetchPidsFromNames([]string). A new Linux-only unit test (TestFetchPidsDeduplicates) passes the same PID string twice in the names slice and asserts that procMap and plist each contain exactly one entry.

## Why is it important?

Without the guard, a duplicate directory entry from Readdirnames results in the same process appearing twice in the process list returned to callers. This could cause metric double-counting or unexpected behavior in downstream consumers.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist


## Related issues

- Closes #299

